### PR TITLE
Fix #125

### DIFF
--- a/woocommerce-abandoned-cart/cron/wcal_send_email.php
+++ b/woocommerce-abandoned-cart/cron/wcal_send_email.php
@@ -414,7 +414,9 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                         $query_email = "SELECT user_email FROM `".$wpdb->prefix."users` WHERE ID = %d";
                     }
                     $results_email       = $wpdb->get_results( $wpdb->prepare( $query_email, $user_id ) );
-                    $user_billing_email  = $results_email[0]->user_email;
+                    if( !empty( $results_email[0]->user_email ) ) {
+                        $user_billing_email = $results_email[0]->user_email;
+                    }
                 }
                 $query_email_id      = "SELECT post_id FROM `" . $wpdb->prefix . "postmeta` WHERE meta_key = '_billing_email' AND meta_value = %s";
                 $results_query_email = $wpdb->get_results( $wpdb->prepare( $query_email_id, $user_billing_email ) );


### PR DESCRIPTION
The PHP notice is because of the variable has no result. So we need to
check that if the result is empty or not.

This issue has been fixed.