### PR TITLE
Version 3.7

### DIFF
--- a/woocommerce-abandoned-cart/woocommerce-ac.php
+++ b/woocommerce-abandoned-cart/woocommerce-ac.php
@@ -3,7 +3,7 @@
 Plugin Name: Abandoned Cart Lite for WooCommerce
 Plugin URI: http://www.tychesoftwares.com/store/premium-plugins/woocommerce-abandoned-cart-pro
 Description: This plugin captures abandoned carts by logged-in users & emails them about it. <strong><a href="http://www.tychesoftwares.com/store/premium-plugins/woocommerce-abandoned-cart-pro">Click here to get the PRO Version.</a></strong>
-Version: 3.6
+Version: 3.7
 Author: Tyche Softwares
 Author URI: http://www.tychesoftwares.com/
 Text Domain: woocommerce-ac


### PR DESCRIPTION
Change log for Version 3.7

This version has 1 bug fix.

Fix - If guest customer places an order by selecting “Create an account”
checkbox or enters the password in “Account password” field on the
checkout page, then an abandoned cart was created after “Cart abandoned
cut off time” is reached. Also, abandoned cart reminder email were sent
to the customers after the order was placed. Now onwards, orders placed
by guest users by registering while placing order will not be captured.