### PR TITLE
Fix #178

### DIFF
--- a/woocommerce-abandoned-cart/cron/wcal_send_email.php
+++ b/woocommerce-abandoned-cart/cron/wcal_send_email.php
@@ -141,9 +141,11 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                                     $email_body = str_replace( "{{customer.lastname}}", $user_last_name, $email_body );                             
                                     $email_body = str_replace( "{{customer.fullname}}", $user_first_name." ".$user_last_name, $email_body );
                                 }                               
-                                $order_date = "";                           
+                                $order_date  = "";  
+                                $date_format = get_option( 'date_format' );
+                                $time_format = get_option( 'time_format' );                         
                                 if( $cart_update_time != "" && $cart_update_time != 0 ) {
-                                    $order_date = date( 'd M, Y h:i A', $cart_update_time );
+                                    $order_date = date_i18n( $date_format . ' ' . $time_format, $cart_update_time );
                                 }                               
                                 $email_body = str_replace( "{{cart.abandoned_date}}", $order_date, $email_body );                               
                                 $query_sent = "INSERT INTO `".$wpdb->prefix."ac_sent_history_lite` ( template_id, abandoned_order_id, sent_time, sent_email_id )

--- a/woocommerce-abandoned-cart/includes/classes/class-wcal-abandoned-orders-table.php
+++ b/woocommerce-abandoned-cart/includes/classes/class-wcal-abandoned-orders-table.php
@@ -282,9 +282,10 @@ class WCAL_Abandoned_Orders_Table extends WP_List_Table {
 		    $cart_info        = json_decode( $value->abandoned_cart_info );
 		    $order_date       = "";
 		    $cart_update_time = $value->abandoned_cart_time;
-		
+			$date_format      = get_option( 'date_format' );
+            $time_format      = get_option( 'time_format' );
 		    if ( $cart_update_time != "" && $cart_update_time != 0 ) {
-		        $order_date = date( 'd M, Y h:i A', $cart_update_time );
+		        $order_date = date_i18n(  $date_format . ' ' . $time_format, $cart_update_time );
 		    }
 		
 		    $ac_cutoff_time = get_option( 'ac_lite_cart_abandoned_time' );

--- a/woocommerce-abandoned-cart/includes/classes/class-wcal-product-report-table.php
+++ b/woocommerce-abandoned-cart/includes/classes/class-wcal-product-report-table.php
@@ -134,8 +134,7 @@ class WCAL_Product_Report_Table extends WP_List_Table {
 		
 		foreach( $recover_query as $recovered_cart_key => $recovered_cart_value ) {
 		    $recovered_cart_info = json_decode( $recovered_cart_value->abandoned_cart_info );
-		    $recovered_cart_dat  = json_decode( $recovered_cart_value->recovered_cart);
-		    $order_date          = "";
+		    $recovered_cart_dat  = json_decode( $recovered_cart_value->recovered_cart);		    
 		    $cart_update_time    = $recovered_cart_value->abandoned_cart_time;
 		    $quantity_total      = 0;
 		    $cart_details        = array();
@@ -147,10 +146,7 @@ class WCAL_Product_Report_Table extends WP_List_Table {
 		            $quantity_total = $quantity_total + $v->quantity;
 		        }
 		    }
-		    	
-		    if ( $cart_update_time != "" && $cart_update_time != 0 ) {
-		        $order_date = date( 'd M, Y h:i A', $cart_update_time );
-		    }
+		    			  
 		    $ac_cutoff_time = get_option( 'ac_lite_cart_abandoned_time' );
 		    $cut_off_time   = $ac_cutoff_time * 60 ;
 		    $current_time   = current_time( 'timestamp' );

--- a/woocommerce-abandoned-cart/includes/classes/class-wcal-recover-orders-table.php
+++ b/woocommerce-abandoned-cart/includes/classes/class-wcal-recover-orders-table.php
@@ -206,7 +206,8 @@ class wcal_Recover_Orders_Table extends WP_List_Table {
 		$return_recovered_orders = array();
 		$per_page         = $this->per_page;
 		$i                = 0;
-		    		
+		$date_format      = get_option( 'date_format' );
+        $time_format 	  = get_option( 'time_format' );      		
 		foreach ( $ac_carts_results as $key => $value ) {    		  
 	        $count_carts += 1;
 	        $cart_detail = json_decode( $value->abandoned_cart_info );
@@ -247,10 +248,10 @@ class wcal_Recover_Orders_Table extends WP_List_Table {
 		    	
 					if( version_compare( $woocommerce->version, '3.0.0', ">=" ) ) {
 	    	        	$recovered_date     = $woo_order->get_date_created();
-						$recovered_date_new = $recovered_date->format( 'd M, Y h:i A');
+						$recovered_date_new = $recovered_date->date_i18n( $date_format . ' ' . $time_format );
 	    	        }else{
 	    	        	$recovered_date     = strtotime( $woo_order->order_date );
-	    	        	$recovered_date_new = date( 'd M, Y h:i A', $recovered_date );
+	    	        	$recovered_date_new = date_i18n( $date_format . ' ' . $time_format, $recovered_date );
 	    	    	}
 
 			        $recovered_item    += 1;
@@ -258,7 +259,7 @@ class wcal_Recover_Orders_Table extends WP_List_Table {
 			        if ( isset( $rec_order ) && $rec_order != false ) {
 			            $recovered_total += $rec_order['_order_total'][0];
 			        }
-			        $abandoned_date        = date( 'd M, Y h:i A', $value->abandoned_cart_time );
+			        $abandoned_date        = date_i18n( $date_format . ' ' . $time_format, $value->abandoned_cart_time );
 			        $abandoned_order_id    = $value->id;
 			        $billing_first_name    = $billing_last_name = $billing_email = '';
 			        $recovered_order_total = 0;

--- a/woocommerce-abandoned-cart/woocommerce-ac.php
+++ b/woocommerce-abandoned-cart/woocommerce-ac.php
@@ -3149,7 +3149,9 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
 				$body_email_preview    = str_replace( '{{customer.lastname}}', 'Doe', $body_email_preview );
 				$body_email_preview    = str_replace( '{{customer.fullname}}', 'John'." ".'Doe', $body_email_preview );
 				$current_time_stamp    = current_time( 'timestamp' );
-				$test_date             = date( 'd M, Y h:i A', $current_time_stamp );
+				$date_format      	   = get_option( 'date_format' );
+                $time_format      	   = get_option( 'time_format' );
+				$test_date             = date_i18n( $date_format . ' ' . $time_format, $current_time_stamp );
 				$body_email_preview    = str_replace( '{{cart.abandoned_date}}', $test_date, $body_email_preview );				
 				$cart_url              = wc_get_page_permalink( 'cart' );
 				$body_email_preview    = str_replace( '{{cart.link}}', $cart_url, $body_email_preview );


### PR DESCRIPTION
Now, our plugin will use the setting of WordPress site language ( Date Format and Time Format ). Abandoned cart date and time format will be translated in the abandoned cart reminder email and test email into the WordPress site language which you have selected.

Also, the same setting will be applied on all tab of our plugin ( Abandoned Orders and Recovered Orders tab ) where we are showing the date and time format.