### PR TITLE
changed in the last commit

### DIFF
--- a/woocommerce-abandoned-cart/cron/wcal_send_email.php
+++ b/woocommerce-abandoned-cart/cron/wcal_send_email.php
@@ -145,7 +145,9 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                                 $date_format = get_option( 'date_format' );
                                 $time_format = get_option( 'time_format' );                         
                                 if( $cart_update_time != "" && $cart_update_time != 0 ) {
-                                    $order_date = date_i18n( $date_format . ' ' . $time_format, $cart_update_time );
+                                	$date_format = date_i18n( get_option( 'date_format' ), $cart_update_time );
+            						$time_format = date_i18n( get_option( 'time_format' ), $cart_update_time );
+                                    $order_date = $date_format . ' ' . $time_format;
                                 }                               
                                 $email_body = str_replace( "{{cart.abandoned_date}}", $order_date, $email_body );                               
                                 $query_sent = "INSERT INTO `".$wpdb->prefix."ac_sent_history_lite` ( template_id, abandoned_order_id, sent_time, sent_email_id )

--- a/woocommerce-abandoned-cart/includes/classes/class-wcal-abandoned-orders-table.php
+++ b/woocommerce-abandoned-cart/includes/classes/class-wcal-abandoned-orders-table.php
@@ -282,10 +282,11 @@ class WCAL_Abandoned_Orders_Table extends WP_List_Table {
 		    $cart_info        = json_decode( $value->abandoned_cart_info );
 		    $order_date       = "";
 		    $cart_update_time = $value->abandoned_cart_time;
-			$date_format      = get_option( 'date_format' );
-            $time_format      = get_option( 'time_format' );
+			
 		    if ( $cart_update_time != "" && $cart_update_time != 0 ) {
-		        $order_date = date_i18n(  $date_format . ' ' . $time_format, $cart_update_time );
+		    	$date_format = date_i18n( get_option( 'date_format' ), $cart_update_time );
+            	$time_format = date_i18n( get_option( 'time_format' ), $cart_update_time );
+		        $order_date  = $date_format . ' ' . $time_format;
 		    }
 		
 		    $ac_cutoff_time = get_option( 'ac_lite_cart_abandoned_time' );

--- a/woocommerce-abandoned-cart/includes/classes/class-wcal-recover-orders-table.php
+++ b/woocommerce-abandoned-cart/includes/classes/class-wcal-recover-orders-table.php
@@ -205,9 +205,7 @@ class wcal_Recover_Orders_Table extends WP_List_Table {
 		$recovered_item   = $recovered_total = $count_carts = $total_value = $order_total = 0;    		
 		$return_recovered_orders = array();
 		$per_page         = $this->per_page;
-		$i                = 0;
-		$date_format      = get_option( 'date_format' );
-        $time_format 	  = get_option( 'time_format' );      		
+		$i                = 0;		
 		foreach ( $ac_carts_results as $key => $value ) {    		  
 	        $count_carts += 1;
 	        $cart_detail = json_decode( $value->abandoned_cart_info );
@@ -247,11 +245,17 @@ class wcal_Recover_Orders_Table extends WP_List_Table {
 		        	$woo_order          = new WC_Order( $recovered_id );
 		    	
 					if( version_compare( $woocommerce->version, '3.0.0', ">=" ) ) {
-	    	        	$recovered_date     = $woo_order->get_date_created();
-						$recovered_date_new = $recovered_date->date_i18n( $date_format . ' ' . $time_format );
+	    	        	$order = get_post( $recovered_id );
+						$recovered_date = strtotime ( $order->post_date );
+						$recovered_date_format    = date_i18n( get_option( 'date_format' ), $recovered_date );
+        				$recovered_time_format 	= date_i18n( get_option( 'time_format' ), $recovered_date ); 
+        						
+						$recovered_date_new = $recovered_date_format . ' ' . $recovered_time_format;
 	    	        }else{
 	    	        	$recovered_date     = strtotime( $woo_order->order_date );
-	    	        	$recovered_date_new = date_i18n( $date_format . ' ' . $time_format, $recovered_date );
+	    	        	$recovered_date_format        = date_i18n( get_option( 'date_format' ), $recovered_date );
+        				$recovered_time_format 	    = date_i18n( get_option( 'time_format' ), $recovered_date ); 
+	    	        	$recovered_date_new = $recovered_date_format . ' ' . $recovered_time_format;
 	    	    	}
 
 			        $recovered_item    += 1;
@@ -259,7 +263,9 @@ class wcal_Recover_Orders_Table extends WP_List_Table {
 			        if ( isset( $rec_order ) && $rec_order != false ) {
 			            $recovered_total += $rec_order['_order_total'][0];
 			        }
-			        $abandoned_date        = date_i18n( $date_format . ' ' . $time_format, $value->abandoned_cart_time );
+			        $date_format      	   = date_i18n( get_option( 'date_format' ), $value->abandoned_cart_time );
+        			$time_format 	  	   = date_i18n( get_option( 'time_format' ), $value->abandoned_cart_time ); 
+			        $abandoned_date        = $date_format . ' ' . $time_format;
 			        $abandoned_order_id    = $value->id;
 			        $billing_first_name    = $billing_last_name = $billing_email = '';
 			        $recovered_order_total = 0;

--- a/woocommerce-abandoned-cart/woocommerce-ac.php
+++ b/woocommerce-abandoned-cart/woocommerce-ac.php
@@ -3149,9 +3149,9 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
 				$body_email_preview    = str_replace( '{{customer.lastname}}', 'Doe', $body_email_preview );
 				$body_email_preview    = str_replace( '{{customer.fullname}}', 'John'." ".'Doe', $body_email_preview );
 				$current_time_stamp    = current_time( 'timestamp' );
-				$date_format      	   = get_option( 'date_format' );
-                $time_format      	   = get_option( 'time_format' );
-				$test_date             = date_i18n( $date_format . ' ' . $time_format, $current_time_stamp );
+				$date_format      	   = date_i18n( get_option( 'date_format' ), $current_time_stamp );
+                $time_format      	   = date_i18n( get_option( 'time_format' ), $current_time_stamp );
+				$test_date             = $date_format . ' ' . $time_format;
 				$body_email_preview    = str_replace( '{{cart.abandoned_date}}', $test_date, $body_email_preview );				
 				$cart_url              = wc_get_page_permalink( 'cart' );
 				$body_email_preview    = str_replace( '{{cart.link}}', $cart_url, $body_email_preview );


### PR DESCRIPTION
I have changed the code of abandoned cart date and format which I had fixed in the last commit. I had used date_i18() function for translating abandoned cart date and time into WordPress site Language which was not allowed to insert the string between date and time. This function is used for retrieving the date in the localized format, based on timestamp.

This fix ensures that if the user wants to add the string between date and time, then the user can update the plugin file.