### PR TITLE
Fix #174, Fix #177, Fix #181

### DIFF
--- a/woocommerce-abandoned-cart/includes/wcal_class-guest.php
+++ b/woocommerce-abandoned-cart/includes/wcal_class-guest.php
@@ -208,8 +208,8 @@ if ( ! class_exists( 'woocommerce_guest_ac' ) ) {
                 $results   = $wpdb->get_results( $wpdb->prepare( $query, $get_cookie[0] ) );
                 
                 if ( count( $results ) == 0 ) {
-                    $insert_query = "INSERT INTO `".$wpdb->prefix."ac_abandoned_cart_history_lite`( user_id, abandoned_cart_info, abandoned_cart_time, cart_ignored, recovered_cart, user_type )
-                                     VALUES ( '".$user_id."', '".$cart_info."', '".$current_time."', '0', '0', 'GUEST' )";
+                    $insert_query = "INSERT INTO `".$wpdb->prefix."ac_abandoned_cart_history_lite`( user_id, abandoned_cart_info, abandoned_cart_time, cart_ignored, recovered_cart, user_type, session_id )
+                                     VALUES ( '".$user_id."', '".$cart_info."', '".$current_time."', '0', '0', 'GUEST', '".$get_cookie[0] ."' )";
                     $wpdb->query( $insert_query );
                     
                     $abandoned_cart_id                  = $wpdb->insert_id;


### PR DESCRIPTION
When the user placed an order and then again come to the site and abandoned a cart for the same day using the same email address then the new cart was being captured. This issue has been fixed.

Now, if the user abandoned a cart for the same day then our plugin will capture the cart but the cart status will be changed to 'Abandoned but new cart created after this' for the same cart after cron job run.