### PR TITLE
Fix #211

### DIFF
--- a/woocommerce-abandoned-cart/cron/wcal_send_email.php
+++ b/woocommerce-abandoned-cart/cron/wcal_send_email.php
@@ -233,14 +233,27 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                                             $name                       = $variation->get_formatted_name() ;
                                             $explode_all                = explode ( "&ndash;", $name );
                                             if( version_compare( $woocommerce->version, '3.0.0', ">=" ) ) {  
-                                                    
-                                                $attributes         = $explode_all[1];
+                                                $attributes         = $explode_all[0];
                                                 $explode_attributes = explode( "(#" , $attributes) ;
-                                                if (isset($explode_attributes [0])){
-                                                    $add_product_name   = $product_name . "," . $explode_attributes[0];
-                                                    $pro_name_variation = (array) $add_product_name;
+                                                if( isset( $explode_attributes[0] ) ) {                                                    
+                                                    $add_product_name =  $explode_attributes[0];
+                                                    $add_product_name = rtrim( $add_product_name );                                                    
+                                                    if ( $product_name == $add_product_name ) {                                                    
+                                                        $wcal_selected_variation = '';
+                                                        $wcal_all_attribute      = $v->variation;
+                                                        $variation_id_only       = $v->variation_id;
+                                                        foreach ($wcal_all_attribute as $wcal_all_attribute_key => $wcal_all_attribute_value) {
+                                                            $taxonomy            = explode( 'attribute_', $wcal_all_attribute_key );
+                                                            $meta                = get_post_meta( $variation_id_only, $wcal_all_attribute_key, true );
+                                                            $term                = get_term_by( 'slug', $meta, $taxonomy[1] );
+                                                            $variation_name_only = $term->name;
+                                                            $wcal_selected_variation .= $variation_name_only . "<br>";
+                                                        }
+                                                        $add_product_name = $product_name . ' - ' . $wcal_selected_variation;
+                                                    }
+                                                    $pro_name_variation   = (array) $add_product_name;                                                    
                                                 }
-                                            }else{
+                                            } else {
                                                 $pro_name_variation         = array_slice( $explode_all, 1, -1 );
                                             }
                                             $product_name_with_variable = '';

--- a/woocommerce-abandoned-cart/woocommerce-ac.php
+++ b/woocommerce-abandoned-cart/woocommerce-ac.php
@@ -2758,15 +2758,28 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                                 $name                       = $variation->get_formatted_name() ;
                                                 $explode_all                = explode ( "&ndash;", $name );
                                                 if( version_compare( $woocommerce->version, '3.0.0', ">=" ) ) {  
-                                                    
-                                                    $attributes         = $explode_all[1];
+                                                    $attributes         = $explode_all[0];
                                                     $explode_attributes = explode( "(#" , $attributes) ;
-                                                    if (isset($explode_attributes [0])){
-                                                        $add_product_name   = $product_name . "," . $explode_attributes[0];
-                                                        $pro_name_variation = (array) $add_product_name;
+                                                    if( isset( $explode_attributes[0] ) ) {                                                    
+                                                        $add_product_name =  $explode_attributes[0];
+                                                        $add_product_name = rtrim( $add_product_name );                                                    
+                                                        if ( $product_name == $add_product_name ) {                                                    
+                                                            $wcal_selected_variation = '';
+                                                            $wcal_all_attribute      = $v->variation;
+                                                            $variation_id_only       = $v->variation_id;
+                                                            foreach ($wcal_all_attribute as $wcal_all_attribute_key => $wcal_all_attribute_value) {
+                                                                $taxonomy            = explode( 'attribute_', $wcal_all_attribute_key );
+                                                                $meta                = get_post_meta( $variation_id_only, $wcal_all_attribute_key, true );
+                                                                $term                = get_term_by( 'slug', $meta, $taxonomy[1] );
+                                                                $variation_name_only = $term->name;
+                                                                $wcal_selected_variation .= $variation_name_only . "<br>";
+                                                            }
+                                                            $add_product_name = $product_name . ' - ' . $wcal_selected_variation;
+                                                        }
+                                                        $pro_name_variation   = (array) $add_product_name;                                                    
                                                     }
                                                 }else{
-                                                    $pro_name_variation         = array_slice( $explode_all, 1, -1 );
+                                                    $pro_name_variation       = array_slice( $explode_all, 1, -1 );
                                                 }
                                                 $product_name_with_variable = '';
                                                 $explode_many_varaition     = array();                                                


### PR DESCRIPTION
When three or more attributes were added for the variatble product, the
slug name of variation were showing instead of variation name on
Abandoned Orders details page and in the Abandoned Cart reminder email.

This issue has been fixed. Now, If number of attributes or number of
variable will be added for variable product then the variation name will
show on Abandoned Order details page and in the abandoned cart reminder
email.