### PR TITLE
Version 4.3

### DIFF
--- a/woocommerce-abandoned-cart/readme.txt
+++ b/woocommerce-abandoned-cart/readme.txt
@@ -4,7 +4,7 @@ Contributors: ashokrane, pinal.shah, bhavik.kiri, chetnapatel, tychesoftwares
 Tags: abandon cart, cart recovery, increase woocommerce conversion rate , recover woocommerce cart, increase sales with woocommerce
 Author URI: https://www.tychesoftwares.com/
 Requires at least: 1.3
-Tested up to: 4.8
+Tested up to: 4.8.1
 Stable tag: trunk
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -177,6 +177,18 @@ You can refer **[here](https://www.tychesoftwares.com/differences-between-pro-an
 6. Product Report Tab.
 
 == Changelog ==
+
+= 4.3 (29.08.2017) =
+
+* This version has 1 bug fix along with 3 Enhancements.
+
+* Bug Fixed - When abandoned cart will have a variable product which has 3 attributes or more than that.  Then the slug name of selected variations were showing in the abandoned cart reminder emails and on the abandoned cart details page. This has been fixed.
+
+* Enhancement - If the abandoned cart total is zero then abandoned cart reminder emails will not be sent to the customers.
+
+* Enhancement - When the email sending script is executed on the server, it was running a large number of MySQL queries for guest users. That was causing an increase in the server load. In this version, we have optimised the queries. Initially, it used to query even those guest user records for which emails were already sent. Now, it will only query those records where email is yet to be sent.
+
+* Enhancement - Removed the Active field from the add / edit email template page. Admin can activate or deactivate the templates from the Email templates page.
 
 = 4.2 (25.07.2017) =
 
@@ -459,6 +471,19 @@ For existing users, this setting will remain unchecked. For new users of the plu
 * Initial release.
 
 == Upgrade Notice ==
+
+= 4.3 (29.08.2017) =
+
+* This version has 1 bug fix along with 3 Enhancements.
+
+* Bug Fixed - When abandoned cart will have a variable product which has 3 attributes or more than that.  Then the slug name of selected variations were showing in the abandoned cart reminder emails and on the abandoned cart details page. This has been fixed.
+
+* Enhancement - If the abandoned cart total is zero then abandoned cart reminder emails will not be sent to the customers.
+
+* Enhancement - When the email sending script is executed on the server, it was running a large number of MySQL queries for guest users. That was causing an increase in the server load. In this version, we have optimised the queries. Initially, it used to query even those guest user records for which emails were already sent. Now, it will only query those records where email is yet to be sent.
+
+* Enhancement - Removed the Active field from the add / edit email template page. Admin can activate or deactivate the templates from the Email templates page.
+
 
 = 4.2 (25.07.2017) =
 

--- a/woocommerce-abandoned-cart/woocommerce-ac.php
+++ b/woocommerce-abandoned-cart/woocommerce-ac.php
@@ -3,7 +3,7 @@
 Plugin Name: Abandoned Cart Lite for WooCommerce
 Plugin URI: http://www.tychesoftwares.com/store/premium-plugins/woocommerce-abandoned-cart-pro
 Description: This plugin captures abandoned carts by logged-in users & emails them about it. <strong><a href="http://www.tychesoftwares.com/store/premium-plugins/woocommerce-abandoned-cart-pro">Click here to get the PRO Version.</a></strong>
-Version: 4.2
+Version: 4.3
 Author: Tyche Softwares
 Author URI: http://www.tychesoftwares.com/
 Text Domain: woocommerce-ac
@@ -423,16 +423,16 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                     $cut_off_time   = $ac_cutoff_time * 60;
                     $compare_time   = $current_time - $cut_off_time;
                 
-
                     if ( $compare_time >  $wcal_cart_abandoned_time ) {
                         /* cart is declared as adandoned */
-
+                        
                         add_post_meta( $order_id , 'wcal_recover_order_placed', $wcal_abandoned_cart_id );
                     }else {
                     /* cart order is placed within the cutoff time.
                     we will delete that abandoned cart */
                   
                     /* if user becomes the registred user */
+
                     if ( isset( $_POST['account_password'] ) && $_POST['account_password'] != '' ) {
 
                         $abandoned_cart_id_new_user = $_SESSION['abandoned_cart_id_lite'];


### PR DESCRIPTION
Changelog for version 4.3 Abandoned Cart LITE for WooCommerce

This version has 1 bug fix along with 3 Enhancements.

1. When abandoned cart will have a variable product which has 3 attributes or more than that.  Then the slug name of selected variations were showing in the abandoned cart reminder emails and on the abandoned cart details page. This has been fixed.

Enhancements:

1. If the abandoned cart total is zero then abandoned cart reminder emails will not be sent to the customers.

2.  When the email sending script is executed on the server, it was running a large number of MySQL queries for guest users. That was causing an increase in the server load. In this version, we have optimised the queries. Initially, it used to query even those guest user records for which emails were already sent. Now, it will only query those records where email is yet to be sent.

3. Removed the Active field from the add / edit email template page. Admin can activate or deactivate the templates from the Email templates page.
