### PR TITLE
Fix #257

### DIFF
--- a/woocommerce-abandoned-cart/includes/classes/class-wcal-recover-orders-table.php
+++ b/woocommerce-abandoned-cart/includes/classes/class-wcal-recover-orders-table.php
@@ -186,20 +186,21 @@ class wcal_Recover_Orders_Table extends WP_List_Table {
 		    $end_date_range = $wcal_class->start_end_dates[$duration_range]['end_date'];
 		}
 		
-		$start_date = strtotime( $start_date_range." 00:01:01" );
-		$end_date   = strtotime( $end_date_range." 23:59:59" );
-		
-		$ac_cutoff_time          = get_option( 'ac_lite_cart_abandoned_time' );
-		$cut_off_time            = $ac_cutoff_time * 60;
-		$current_time            = current_time( 'timestamp' );
-		$compare_time            = $current_time - $cut_off_time;
+		$start_date 		   = strtotime( $start_date_range." 00:01:01" );
+		$end_date   		   = strtotime( $end_date_range." 23:59:59" );
+		$ac_cutoff_time        = get_option( 'ac_lite_cart_abandoned_time' );
+		$cut_off_time          = $ac_cutoff_time * 60;
+		$current_time          = current_time( 'timestamp' );
+		$compare_time          = $current_time - $cut_off_time;
+		$blank_cart_info       = '{"cart":[]}';
+		$blank_cart_info_guest = '[]';
 		
 		$query_ac         = "SELECT * FROM " . $wpdb->prefix . "ac_abandoned_cart_history_lite 
-		                      WHERE abandoned_cart_time >= %d AND abandoned_cart_time <= %d AND recovered_cart > 0 AND abandoned_cart_time <= '$compare_time' ORDER BY recovered_cart desc";
+		                      WHERE abandoned_cart_time >= %d AND abandoned_cart_time <= %d AND recovered_cart > 0 AND abandoned_cart_time <= '$compare_time' AND abandoned_cart_info NOT LIKE '%$blank_cart_info%' AND abandoned_cart_info NOT LIKE '$blank_cart_info_guest' ORDER BY recovered_cart desc";
 		$ac_results       = $wpdb->get_results( $wpdb->prepare( $query_ac, $start_date, $end_date ) );
 		
 		$query_ac_carts   = "SELECT * FROM " . $wpdb->prefix . "ac_abandoned_cart_history_lite 
-		                     WHERE abandoned_cart_time >= %d AND abandoned_cart_time <= %d AND abandoned_cart_time <= '$compare_time' ";
+		                     WHERE abandoned_cart_time >= %d AND abandoned_cart_time <= %d AND abandoned_cart_time <= '$compare_time' AND abandoned_cart_info NOT LIKE '%$blank_cart_info%' AND abandoned_cart_info NOT LIKE '$blank_cart_info_guest' ";
 		$ac_carts_results = $wpdb->get_results( $wpdb->prepare( $query_ac_carts, $start_date, $end_date ) );
 		
 		$recovered_item   = $recovered_total = $count_carts = $total_value = $order_total = 0;    		
@@ -227,38 +228,34 @@ class wcal_Recover_Orders_Table extends WP_List_Table {
 	        $total_value += $line_total; 
 		}
 		$total_value                      = wc_price( $total_value );    		
-		$this->total_order_amount         = $total_value ;
-		$this->total_abandoned_cart_count = $count_carts ;    		
+		$this->total_order_amount         = $total_value;
+		$this->total_abandoned_cart_count = $count_carts;    		
 		$recovered_order_total            = 0;    		
-		$this->total_recover_amount       = round( $recovered_order_total, $number_decimal )  ;    		
+		$this->total_recover_amount       = round( $recovered_order_total, $number_decimal );    		
 		$this->recovered_item             = 0;    		
 		$table_data                       = "";
 		
 		foreach ( $ac_results as $key => $value ) {    		        		
 		    if( $value->recovered_cart != 0 ) {    		        
 		        $return_recovered_orders[$i] = new stdClass();
-		        
-		        $recovered_id       = $value->recovered_cart;
-		        $rec_order          = get_post_meta( $recovered_id );
-		        $woo_order = array();
+		        $recovered_id       		 = $value->recovered_cart;
+		        $rec_order          		 = get_post_meta( $recovered_id );
+		        $woo_order 					 = array();
 		        try{
-		        	$woo_order          = new WC_Order( $recovered_id );
-		    	
+		        	$woo_order          	   = new WC_Order( $recovered_id );
 					if( version_compare( $woocommerce->version, '3.0.0', ">=" ) ) {
-	    	        	$order = get_post( $recovered_id );
-						$recovered_date = strtotime ( $order->post_date );
-						$recovered_date_format    = date_i18n( get_option( 'date_format' ), $recovered_date );
-        				$recovered_time_format 	= date_i18n( get_option( 'time_format' ), $recovered_date ); 
-        						
-						$recovered_date_new = $recovered_date_format . ' ' . $recovered_time_format;
-	    	        }else{
-	    	        	$recovered_date     = strtotime( $woo_order->order_date );
-	    	        	$recovered_date_format        = date_i18n( get_option( 'date_format' ), $recovered_date );
-        				$recovered_time_format 	    = date_i18n( get_option( 'time_format' ), $recovered_date ); 
-	    	        	$recovered_date_new = $recovered_date_format . ' ' . $recovered_time_format;
+	    	        	$order 				   = get_post( $recovered_id );
+						$recovered_date 	   = strtotime ( $order->post_date );
+						$recovered_date_format = date_i18n( get_option( 'date_format' ), $recovered_date );
+        				$recovered_time_format = date_i18n( get_option( 'time_format' ), $recovered_date ); 
+						$recovered_date_new    = $recovered_date_format . ' ' . $recovered_time_format;
+	    	        } else {
+	    	        	$recovered_date        = strtotime( $woo_order->order_date );
+	    	        	$recovered_date_format = date_i18n( get_option( 'date_format' ), $recovered_date );
+        				$recovered_time_format = date_i18n( get_option( 'time_format' ), $recovered_date ); 
+	    	        	$recovered_date_new    = $recovered_date_format . ' ' . $recovered_time_format;
 	    	    	}
-
-			        $recovered_item    += 1;
+			        $recovered_item += 1;
 			
 			        if ( isset( $rec_order ) && $rec_order != false ) {
 			            $recovered_total += $rec_order['_order_total'][0];
@@ -270,19 +267,19 @@ class wcal_Recover_Orders_Table extends WP_List_Table {
 			        $billing_first_name    = $billing_last_name = $billing_email = '';
 			        $recovered_order_total = 0;
 			
-			        if ( isset( $rec_order['_billing_first_name'][0] ) ) {
+			        if( isset( $rec_order['_billing_first_name'][0] ) ) {
 			            $billing_first_name = $rec_order['_billing_first_name'][0];
 			        }
 			
-			        if ( isset( $rec_order['_billing_last_name'][0] ) ) {
+			        if( isset( $rec_order['_billing_last_name'][0] ) ) {
 			            $billing_last_name = $rec_order['_billing_last_name'][0];
 			        }
 			
-			        if ( isset( $rec_order['_billing_email'][0] ) ) {
+			        if( isset( $rec_order['_billing_email'][0] ) ) {
 			            $billing_email = $rec_order['_billing_email'][0];
 			        }
 			
-			        if ( isset( $rec_order['_order_total'][0] ) ) {
+			        if( isset( $rec_order['_order_total'][0] ) ) {
 			            $recovered_order_total = $rec_order['_order_total'][0];
 			        }
 			        
@@ -296,7 +293,7 @@ class wcal_Recover_Orders_Table extends WP_List_Table {
 			        $return_recovered_orders[ $i ]->order_total        = wc_price($recovered_order_total);
 			            		        
 			        $this->recovered_item = $recovered_item;
-			        $this->total_recover_amount = round( ( $recovered_order_total + $this->total_recover_amount ) , $number_decimal );    		        
+			        $this->total_recover_amount = round( ( $recovered_order_total + $this->total_recover_amount ), $number_decimal );    		        
 			        $i++;
 			    }catch (Exception $e){
 			    	
@@ -315,10 +312,10 @@ class wcal_Recover_Orders_Table extends WP_List_Table {
 			}
 		}
 		// sort for customer name
-		else if ( isset( $_GET['orderby']) && $_GET['orderby'] == 'recovered_date' ) {
+		else if( isset( $_GET['orderby'] ) && $_GET['orderby'] == 'recovered_date' ) {
 		if( isset( $_GET['order'] ) && $_GET['order'] == 'asc' ) {
 				usort( $return_recovered_orders, array( __CLASS__ , "wcal_class_recovered_date_asc" ) );
-			}else {
+			} else {
 				usort( $return_recovered_orders, array( __CLASS__ , "wcal_class_recovered_date_dsc" ) );
 			}
 		}


### PR DESCRIPTION
When the user places an order and goes to the order received page, blank
carts were added in in the database.

So, this fix ensures that recovered orders cannot be duplicated under
Recovered ORders tab.