### PR TITLE
Fix #268

### DIFF
--- a/woocommerce-abandoned-cart/cron/wcal_send_email.php
+++ b/woocommerce-abandoned-cart/cron/wcal_send_email.php
@@ -64,7 +64,7 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                 }
                 $template_id         = $value->id;
                 $is_wc_template      = $value->is_wc_template;
-                $wc_template_header_text = $value->wc_email_header != '' ? $value->wc_email_header : __( 'Abandoned cart reminder', 'woocommerce-ac');
+                $wc_template_header_text = $value->wc_email_header != '' ? $value->wc_email_header : __( 'Abandoned cart reminder', 'woocommerce-abandoned-cart');
                 $wc_template_header  = stripslashes( $wc_template_header_text );
                 if ( '' != $email_body_template ) { 
                     foreach ( $carts as $key => $value ) {
@@ -245,23 +245,23 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                                             if( preg_match( "{{products.cart}}", $email_body, $matched ) ) {
                                                 if ( class_exists( 'WP_Better_Emails' ) ) {
                                                     $var = '<table width = 100%>
-                                                            <tr> <td colspan="5"> <h3>'.__( "Your Shopping Cart", "woocommerce-ac" ).'</h3> </td></tr>
+                                                            <tr> <td colspan="5"> <h3>'.__( "Your Shopping Cart", "woocommerce-abandoned-cart" ).'</h3> </td></tr>
                                                             <tr>
-                                                            <th>'.__( "Item", "woocommerce-ac" ).'</th>
-                                                            <th>'.__( "Name", "woocommerce-ac" ).'</th>
-                                                            <th>'.__( "Quantity", "woocommerce-ac" ).'</th>
-                                                            <th>'.__( "Price", "woocommerce-ac" ).'</th>
-                                                            <th>'.__( "Line Subtotal", "woocommerce-ac" ).'</th>
+                                                            <th>'.__( "Item", "woocommerce-abandoned-cart" ).'</th>
+                                                            <th>'.__( "Name", "woocommerce-abandoned-cart" ).'</th>
+                                                            <th>'.__( "Quantity", "woocommerce-abandoned-cart" ).'</th>
+                                                            <th>'.__( "Price", "woocommerce-abandoned-cart" ).'</th>
+                                                            <th>'.__( "Line Subtotal", "woocommerce-abandoned-cart" ).'</th>
                                                             </tr>';
                                                 } else {
-                                                    $var = '<h3>'.__( "Your Shopping Cart", "woocommerce-ac" ).'</h3>
+                                                    $var = '<h3>'.__( "Your Shopping Cart", "woocommerce-abandoned-cart" ).'</h3>
                                                         <table border="0" cellpadding="10" cellspacing="0" class="templateDataTable">
                                                             <tr>
-                                                            <th>'.__( "Item", "woocommerce-ac" ).'</th>
-                                                            <th>'.__( "Name", "woocommerce-ac" ).'</th>
-                                                            <th>'.__( "Quantity", "woocommerce-ac" ).'</th>
-                                                            <th>'.__( "Price", "woocommerce-ac" ).'</th>
-                                                            <th>'.__( "Line Subtotal", "woocommerce-ac" ).'</th>
+                                                            <th>'.__( "Item", 'woocommerce-abandoned-cart' ).'</th>
+                                                            <th>'.__( "Name", 'woocommerce-abandoned-cart' ).'</th>
+                                                            <th>'.__( "Quantity", 'woocommerce-abandoned-cart' ).'</th>
+                                                            <th>'.__( "Price", 'woocommerce-abandoned-cart' ).'</th>
+                                                            <th>'.__( "Line Subtotal", 'woocommerce-abandoned-cart' ).'</th>
                                                             </tr>';
                                                 }                   
                                                 $cart_details = $cart_info_db_field->cart;
@@ -324,7 +324,7 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                                                         }
                                                         $var .='<tr align="center">
                                                                 <td> <a href="'.$cart_link_track.'"> <img src="' . $image_url . '" alt="" height="42" width="42" /> </a></td>
-                                                                <td> <a href="'.$cart_link_track.'">'.__( $product_name, "woocommerce-ac" ).'</a></td>
+                                                                <td> <a href="'.$cart_link_track.'">'.__( $product_name, 'woocommerce-abandoned-cart' ).'</a></td>
                                                                 <td> '.$quantity_total.'</td>
                                                                 <td> '.$item_subtotal.'</td>
                                                                 <td> '.$item_total_display.'</td>
@@ -337,13 +337,13 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                                                             <td> </td>
                                                             <td> </td>
                                                             <td> </td>
-                                                            <td>'.__( "Cart Total:", "woocommerce-ac" ).'</td>
+                                                            <td>'.__( "Cart Total:", 'woocommerce-abandoned-cart' ).'</td>
                                                             <td> '.$cart_total.'</td>
                                                         </tr>';
                                                     $var .= '</table>
                                                                             ';
                                                     $email_body    = str_replace( "{{products.cart}}", $var, $email_body );
-                                                    $email_subject = str_replace( "{{product.name}}", __( $sub_line_prod_name, "woocommerce-ac" ), $email_subject );
+                                                    $email_subject = str_replace( "{{product.name}}", __( $sub_line_prod_name, 'woocommerce-abandoned-cart' ), $email_subject );
                                                 }
                                             
                                                 $user_email       = $value->user_email;
@@ -365,7 +365,7 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                                                     wc_mail( $user_email, $email_subject, $final_email_body, $headers );
                                             
                                                 } else {
-                                                    wp_mail( $user_email, $email_subject, __( $email_body_final, 'woocommerce-ac' ), $headers );
+                                                    wp_mail( $user_email, $email_subject, __( $email_body_final, 'woocommerce-abandoned-cart' ), $headers );
                                                 }
                                             }
                                         }                                       
@@ -479,7 +479,7 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                             $query_order = "UPDATE `" . $wpdb->prefix."ac_abandoned_cart_history_lite` SET recovered_cart= '" . $order_id . "', cart_ignored = '1' WHERE id = '".$cart_id."' ";
                             $wpdb->query( $query_order );
 
-                            $order->add_order_note( __( 'This order was abandoned & subsequently recovered.', 'woocommerce-ac' ) );
+                            $order->add_order_note( __( 'This order was abandoned & subsequently recovered.', 'woocommerce-abandoned-cart' ) );
 
                             delete_post_meta( $order_id,  'wcal_recover_order_placed',         $cart_id );
                             delete_post_meta( $order_id , 'wcal_recover_order_placed_sent_id', $wcal_check_email_sent_to_cart );
@@ -536,7 +536,7 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                             $query_order = "UPDATE `" . $wpdb->prefix."ac_abandoned_cart_history_lite` SET recovered_cart= '" . $order_id . "', cart_ignored = '1' WHERE id = '".$cart_id."' ";
                             $wpdb->query( $query_order );
 
-                            $order->add_order_note( __( 'This order was abandoned & subsequently recovered.', 'woocommerce-ac' ) );
+                            $order->add_order_note( __( 'This order was abandoned & subsequently recovered.', 'woocommerce-abandoned-cart' ) );
 
                             delete_post_meta( $order_id,  'wcap_recover_order_placed',         $cart_id );
                             delete_post_meta( $order_id , 'wcap_recover_order_placed_sent_id', $wcal_check_email_sent_to_cart );

--- a/woocommerce-abandoned-cart/includes/classes/class-wcal-abandoned-orders-table.php
+++ b/woocommerce-abandoned-cart/includes/classes/class-wcal-abandoned-orders-table.php
@@ -39,8 +39,8 @@ class WCAL_Abandoned_Orders_Table extends WP_List_Table {
 		global $status, $page;
 		// Set parent defaults
 		parent::__construct( array(
-		        'singular' => __( 'abandoned_order_id', 'woocommerce-ac' ), //singular name of the listed records
-		        'plural'   => __( 'abandoned_order_ids', 'woocommerce-ac' ), //plural name of the listed records
+		        'singular' => __( 'abandoned_order_id', 'woocommerce-abandoned-cart' ), //singular name of the listed records
+		        'plural'   => __( 'abandoned_order_ids', 'woocommerce-abandoned-cart' ), //plural name of the listed records
 				'ajax'     => false             			// Does this table support ajax?
 		) );
 		$this->process_bulk_action();
@@ -73,12 +73,12 @@ class WCAL_Abandoned_Orders_Table extends WP_List_Table {
 	    $columns = array();
 		$columns = array(
  		        'cb'          => '<input type="checkbox" />',
-                'id'          => __( 'Id', 'woocommerce-ac' ),
-                'email'       => __( 'Email Address', 'woocommerce-ac' ),
-				'customer'    => __( 'Customer', 'woocommerce-ac' ),
-				'order_total' => __( 'Order Total', 'woocommerce-ac' ),		        
-				'date'        => __( 'Abandoned Date', 'woocommerce-ac' ),
-				'status'      => __( 'Status of Cart', 'woocommerce-ac' )
+                'id'          => __( 'Id', 'woocommerce-abandoned-cart' ),
+                'email'       => __( 'Email Address', 'woocommerce-abandoned-cart' ),
+				'customer'    => __( 'Customer', 'woocommerce-abandoned-cart' ),
+				'order_total' => __( 'Order Total', 'woocommerce-abandoned-cart' ),		        
+				'date'        => __( 'Abandoned Date', 'woocommerce-abandoned-cart' ),
+				'status'      => __( 'Status of Cart', 'woocommerce-abandoned-cart' )
 		);
 		return apply_filters( 'wcal_abandoned_orders_columns', $columns );
 	}
@@ -122,8 +122,8 @@ class WCAL_Abandoned_Orders_Table extends WP_List_Table {
 	    $abandoned_order_id 	= 0;
 	    if( isset( $abandoned_row_info->email ) ) {	    
 		    $abandoned_order_id    = $abandoned_row_info->id ; 
-		    $row_actions['edit']   = '<a href="' . wp_nonce_url( add_query_arg( array( 'action' => 'orderdetails', 'id' => $abandoned_row_info->id ), $this->base_url ), 'abandoned_order_nonce') . '">' . __( 'View order', 'woocommerce-ac' ) . '</a>';
-		    $row_actions['delete'] = '<a href="' . wp_nonce_url( add_query_arg( array( 'action' => 'wcal_delete', 'abandoned_order_id' => $abandoned_row_info->id ), $this->base_url ), 'abandoned_order_nonce') . '">' . __( 'Delete', 'woocommerce-ac' ) . '</a>';	
+		    $row_actions['edit']   = '<a href="' . wp_nonce_url( add_query_arg( array( 'action' => 'orderdetails', 'id' => $abandoned_row_info->id ), $this->base_url ), 'abandoned_order_nonce') . '">' . __( 'View order', 'woocommerce-abandoned-cart' ) . '</a>';
+		    $row_actions['delete'] = '<a href="' . wp_nonce_url( add_query_arg( array( 'action' => 'wcal_delete', 'abandoned_order_id' => $abandoned_row_info->id ), $this->base_url ), 'abandoned_order_nonce') . '">' . __( 'Delete', 'woocommerce-abandoned-cart' ) . '</a>';	
 		    $email                 = $abandoned_row_info->email;
 		    $value                 = $email . $this->row_actions( $row_actions );	    
 	    }	
@@ -314,15 +314,15 @@ class WCAL_Abandoned_Orders_Table extends WP_List_Table {
 		    }
 		
 		    if ( 1 == $quantity_total ) {
-		        $item_disp = __("item", "woocommerce-ac");
+		        $item_disp = __("item", "woocommerce-abandoned-cart");
 		    } else {
-		        $item_disp = __("items", "woocommerce-ac");
+		        $item_disp = __("items", "woocommerce-abandoned-cart");
 		    }
 		    
 		    if( $value->cart_ignored == 0 && $value->recovered_cart == 0 ) {
-		        $ac_status = __( "Abandoned", "woocommerce-ac" );
+		        $ac_status = __( "Abandoned", "woocommerce-abandoned-cart" );
 		    } elseif( $value->cart_ignored == 1 && $value->recovered_cart == 0 ) {
-		        $ac_status = __( "Abandoned but new","woocommerce-ac" )."</br>". __( "cart created after this", "woocommerce-ac" );
+		        $ac_status = __( "Abandoned but new","woocommerce-abandoned-cart" )."</br>". __( "cart created after this", "woocommerce-abandoned-cart" );
 		    } else {
 		        $ac_status = "";
 		    }
@@ -461,7 +461,7 @@ class WCAL_Abandoned_Orders_Table extends WP_List_Table {
 	
 	public function get_bulk_actions() {
 	    return array(
-	        'wcal_delete' => __( 'Delete', 'woocommerce-ac' )
+	        'wcal_delete' => __( 'Delete', 'woocommerce-abandoned-cart' )
 	    );
 	}
 	

--- a/woocommerce-abandoned-cart/includes/classes/class-wcal-product-report-table.php
+++ b/woocommerce-abandoned-cart/includes/classes/class-wcal-product-report-table.php
@@ -79,8 +79,8 @@ class WCAL_Product_Report_Table extends WP_List_Table {
 		global $status, $page;
 		// Set parent defaults
 		parent::__construct( array(
-		        'singular' => __( 'product_id', 'woocommerce-ac' ), //singular name of the listed records
-		        'plural'   => __( 'product_ids', 'woocommerce-ac' ), //plural name of the listed records
+		        'singular' => __( 'product_id', 'woocommerce-abandoned-cart' ), //singular name of the listed records
+		        'plural'   => __( 'product_ids', 'woocommerce-abandoned-cart' ), //plural name of the listed records
 				'ajax'      => false             			// Does this table support ajax?
 		) );		
 		$this->base_url = admin_url( 'admin.php?page=woocommerce_ac_page&action=stats' );
@@ -103,9 +103,9 @@ class WCAL_Product_Report_Table extends WP_List_Table {
 	
 	public function get_columns() {	    
 	    $columns = array( 		        
-	            'product_name'     => __( 'Product Name', 'woocommerce-ac' ),
-                'abandoned_number' => __( 'Number of Times Abandoned', 'woocommerce-ac' ),
-		        'recover_number'   => __( 'Number of Times Recovered', 'woocommerce-ac' )				
+	            'product_name'     => __( 'Product Name', 'woocommerce-abandoned-cart' ),
+                'abandoned_number' => __( 'Number of Times Abandoned', 'woocommerce-abandoned-cart' ),
+		        'recover_number'   => __( 'Number of Times Recovered', 'woocommerce-abandoned-cart' )				
 	    );		
 	   return apply_filters( 'wcal_product_report_columns', $columns );
 	}

--- a/woocommerce-abandoned-cart/includes/classes/class-wcal-recover-orders-table.php
+++ b/woocommerce-abandoned-cart/includes/classes/class-wcal-recover-orders-table.php
@@ -73,8 +73,8 @@ class wcal_Recover_Orders_Table extends WP_List_Table {
 		global $status, $page;
 		// Set parent defaults
 		parent::__construct( array(
-		        'singular' => __( 'rec_abandoned_id', 'woocommerce-ac' ), //singular name of the listed records
-		        'plural'   => __( 'rec_abandoned_ids', 'woocommerce-ac' ), //plural name of the listed records
+		        'singular' => __( 'rec_abandoned_id', 'woocommerce-abandoned-cart' ), //singular name of the listed records
+		        'plural'   => __( 'rec_abandoned_ids', 'woocommerce-abandoned-cart' ), //plural name of the listed records
 				'ajax'     => false             			// Does this table support ajax?
 		) );			
         $this->base_url = admin_url( 'admin.php?page=woocommerce_ac_page&action=stats' );
@@ -102,11 +102,11 @@ class wcal_Recover_Orders_Table extends WP_List_Table {
 	
 	public function get_columns() {	    
 	    $columns = array( 		        
-                'user_name'       => __( 'Customer Name', 'woocommerce-ac' ),
-		        'user_email_id'   => __( 'Email Address', 'woocommerce-ac' ),
-				'created_on'      => __( 'Cart Abandoned Date', 'woocommerce-ac' ),				
-	            'recovered_date'  => __( 'Cart Recovered Date' , 'woocommerce-ac'),
-	            'order_total'     => __( 'Order Total', 'woocommerce-ac' )				
+                'user_name'       => __( 'Customer Name', 'woocommerce-abandoned-cart' ),
+		        'user_email_id'   => __( 'Email Address', 'woocommerce-abandoned-cart' ),
+				'created_on'      => __( 'Cart Abandoned Date', 'woocommerce-abandoned-cart' ),				
+	            'recovered_date'  => __( 'Cart Recovered Date' , 'woocommerce-abandoned-cart'),
+	            'order_total'     => __( 'Order Total', 'woocommerce-abandoned-cart' )				
 		);		
 	   return apply_filters( 'wcal_recovered_orders_columns', $columns );
 	}
@@ -136,7 +136,7 @@ class wcal_Recover_Orders_Table extends WP_List_Table {
 	    
 	    if( isset( $recovered_orders_row_info->user_name ) ) {
     	    $recovered_id                = $recovered_orders_row_info->recovered_id ;
-    	    $row_actions['view_details'] = "<a target=_blank href = post.php?post=$recovered_id&action=edit>". __( 'View Details', 'woocommerce-ac' )."</a>";
+    	    $row_actions['view_details'] = "<a target=_blank href = post.php?post=$recovered_id&action=edit>". __( 'View Details', 'woocommerce-abandoned-cart' )."</a>";
     	    $user_name                   = $recovered_orders_row_info->user_name;
             $value                       = $user_name . $this->row_actions( $row_actions );
 	    }	

--- a/woocommerce-abandoned-cart/includes/classes/class-wcal-templates-table.php
+++ b/woocommerce-abandoned-cart/includes/classes/class-wcal-templates-table.php
@@ -40,8 +40,8 @@ class WCAL_Templates_Table extends WP_List_Table {
 		global $status, $page;
 		// Set parent defaults
 		parent::__construct( array(
-		        'singular' => __( 'template_id', 'woocommerce-ac' ), //singular name of the listed records
-		        'plural'   => __( 'template_ids', 'woocommerce-ac' ), //plural name of the listed records
+		        'singular' => __( 'template_id', 'woocommerce-abandoned-cart' ), //singular name of the listed records
+		        'plural'   => __( 'template_ids', 'woocommerce-abandoned-cart' ), //plural name of the listed records
 				'ajax'     => false             			// Does this table support ajax?
 		) );
 		$this->process_bulk_action();
@@ -69,10 +69,10 @@ class WCAL_Templates_Table extends WP_List_Table {
 	public function get_columns() {	    
 	    $columns = array(
  		        'cb'            => '<input type="checkbox" />',
-                'sr'            => __( 'Sr', 'woocommerce-ac' ),
-		        'template_name' => __( 'Name Of Template', 'woocommerce-ac' ),
-				'sent_time'     => __( 'Sent After Set Time', 'woocommerce-ac' ),
-				'activate'  	=> __( 'Active ?', 'woocommerce-ac' )			
+                'sr'            => __( 'Sr', 'woocommerce-abandoned-cart' ),
+		        'template_name' => __( 'Name Of Template', 'woocommerce-abandoned-cart' ),
+				'sent_time'     => __( 'Sent After Set Time', 'woocommerce-abandoned-cart' ),
+				'activate'  	=> __( 'Active ?', 'woocommerce-abandoned-cart' )			
 		);		
 	   return apply_filters( 'wcal_templates_columns', $columns );
 	}	
@@ -116,8 +116,8 @@ class WCAL_Templates_Table extends WP_List_Table {
 	    if( isset( $template_row_info->template_name ) ) {	    
     	    $template_id = $template_row_info->id ; 
     	    
-    	    $row_actions['edit']   = '<a href="' . wp_nonce_url( add_query_arg( array( 'action' => 'emailtemplates', 'mode'=>'edittemplate', 'id' => $template_row_info->id ), $this->base_url ), 'abandoned_order_nonce') . '">' . __( 'Edit', 'woocommerce-ac' ) . '</a>';
-    	    $row_actions['delete'] = '<a href="' . wp_nonce_url( add_query_arg( array( 'action' => 'wcal_delete_template', 'template_id' => $template_row_info->id ), $this->base_url ), 'abandoned_order_nonce') . '">' . __( 'Delete', 'woocommerce-ac' ) . '</a>';
+    	    $row_actions['edit']   = '<a href="' . wp_nonce_url( add_query_arg( array( 'action' => 'emailtemplates', 'mode'=>'edittemplate', 'id' => $template_row_info->id ), $this->base_url ), 'abandoned_order_nonce') . '">' . __( 'Edit', 'woocommerce-abandoned-cart' ) . '</a>';
+    	    $row_actions['delete'] = '<a href="' . wp_nonce_url( add_query_arg( array( 'action' => 'wcal_delete_template', 'template_id' => $template_row_info->id ), $this->base_url ), 'abandoned_order_nonce') . '">' . __( 'Delete', 'woocommerce-abandoned-cart' ) . '</a>';
     	    
     	    $email = $template_row_info->template_name;
             $value = $email . $this->row_actions( $row_actions );	    
@@ -152,7 +152,7 @@ class WCAL_Templates_Table extends WP_List_Table {
 		    $return_templates_data[ $i ]->sr            = $i+1;
 		    $return_templates_data[ $i ]->id            = $id;
 		    $return_templates_data[ $i ]->template_name = $value->template_name;
-		    $return_templates_data[ $i ]->sent_time     = __( $frequency . " " . $day_or_hour . " After Abandonment", 'woocommerce-ac' );
+		    $return_templates_data[ $i ]->sent_time     = __( $frequency . " " . $day_or_hour . "After Abandonment", 'woocommerce-abandoned-cart' );
 		    $return_templates_data[ $i ]->activate      = $active;
 		    $return_templates_data[ $i ]->is_active     = $is_active;
 		    $i++;  		        		    
@@ -239,7 +239,7 @@ class WCAL_Templates_Table extends WP_List_Table {
 			       } else {
 			           $active = "off";
 			       }
-			       $active_text   = __( $active, 'woocommerce-ac' ); 
+			       $active_text   = __( $active, 'woocommerce-abandoned-cart' ); 
 			       //$value   = '<a href="#" onclick="wcal_activate_email_template('. $id.', '.$is_active.' )"> '.$active_text.'</a>'; 				
 			       $value =  '<button type="button" class="wcal-switch wcal-toggle-template-status" '
 					. 'wcal-template-id="'. $id .'" '
@@ -256,7 +256,7 @@ class WCAL_Templates_Table extends WP_List_Table {
 	
 	public function get_bulk_actions() {
 	    return array(
-	        'wcal_delete_template' => __( 'Delete', 'woocommerce-ac' )
+	        'wcal_delete_template' => __( 'Delete', 'woocommerce-abandoned-cart' )
 	    );
 	}
 }

--- a/woocommerce-abandoned-cart/includes/wcal_admin_notice.php
+++ b/woocommerce-abandoned-cart/includes/wcal_admin_notice.php
@@ -25,7 +25,7 @@ class Wcal_Admin_Notice {
                 
                 $wcal_ac_pro_link = 'https://www.tychesoftwares.com/store/premium-plugins/woocommerce-abandoned-cart-pro/checkout?edd_action=add_to_cart&download_id=20&utm_source=wpnotice&utm_medium=first&utm_campaign=AbandonedCartLitePlugin';
 
-                $message = wp_kses_post ( __( 'Thank you for using Abandoned Cart Lite for WooCommerce! You can use the Pro version for recovering more sales with some additional features. <strong><a target="_blank" href= "'.$wcal_ac_pro_link.'">Get it now!</a></strong>', 'woocommerce-ac' ) );
+                $message = wp_kses_post ( __( 'Thank you for using Abandoned Cart Lite for WooCommerce! You can use the Pro version for recovering more sales with some additional features. <strong><a target="_blank" href= "'.$wcal_ac_pro_link.'">Get it now!</a></strong>', 'woocommerce-abandoned-cart' ) );
 
                 $add_query_arguments = add_query_arg( 'wcal_pro_first_notice_ignore', '0' );
                 $cancel_button = '<a href="'.$add_query_arguments.'" class="dashicons dashicons-dismiss dashicons-dismiss-icon" style="position: absolute; top: 8px; right: 8px; color: #222; opacity: 0.4; text-decoration: none !important;"></a>';
@@ -43,7 +43,7 @@ class Wcal_Admin_Notice {
 
                     $wcal_ac_pro_link = 'https://www.tychesoftwares.com/store/premium-plugins/woocommerce-abandoned-cart-pro/checkout?edd_action=add_to_cart&download_id=20&utm_source=wpnotice&utm_medium=second&utm_campaign=AbandonedCartLitePlugin';
 
-                    $message = wp_kses_post ( __( 'Abandoned Cart Pro plugin allows you to recover more revenue by offering discount coupons in the abandoned cart email notifications. <strong><a target="_blank" href= "'.$wcal_ac_pro_link.'">Grab it now!</a></strong>', 'woocommerce-ac' ) );
+                    $message = wp_kses_post ( __( 'Abandoned Cart Pro plugin allows you to recover more revenue by offering discount coupons in the abandoned cart email notifications. <strong><a target="_blank" href= "'.$wcal_ac_pro_link.'">Grab it now!</a></strong>', 'woocommerce-abandoned-cart' ) );
 
                     $add_query_arguments = add_query_arg( 'wcal_pro_second_notice_ignore', '0' );
                     $cancel_button = '<a href="'.$add_query_arguments.'" class="dashicons dashicons-dismiss dashicons-dismiss-icon" style="position: absolute; top: 8px; right: 8px; color: #222; opacity: 0.4; text-decoration: none !important;"></a>';
@@ -66,7 +66,7 @@ class Wcal_Admin_Notice {
 
                     $wcal_ordd_lite_link = admin_url( '/plugin-install.php?s=order+delivery+date+tyche+softwares&tab=search&type=term' );
 
-                    $message = wp_kses_post ( __( 'Reduce cart abandonment rate by 57% with our FREE Order Delivery Date plugin. Also increase customer satisfaction with this simple plugin. <strong><a target="_blank" href= "'.$wcal_ordd_lite_link.'">Install Now</a></strong>.', 'woocommerce-ac' ) );
+                    $message = wp_kses_post ( __( 'Reduce cart abandonment rate by 57% with our FREE Order Delivery Date plugin. Also increase customer satisfaction with this simple plugin. <strong><a target="_blank" href= "'.$wcal_ordd_lite_link.'">Install Now</a></strong>.', 'woocommerce-abandoned-cart' ) );
                     $add_query_arguments = add_query_arg( 'wcal_pro_third_notice_ignore', '0' );
                     $cancel_button = '<a href="'.$add_query_arguments.'" class="dashicons dashicons-dismiss dashicons-dismiss-icon" style="position: absolute; top: 8px; right: 8px; color: #222; opacity: 0.4; text-decoration: none !important;"></a>';
                     printf( '<div class="%1$s" style="%2$s"><p>%3$s %4$s</p></div>', $class, $style, $message, $cancel_button );
@@ -90,7 +90,7 @@ class Wcal_Admin_Notice {
 
                     $wcal_pro_diff = 'https://www.tychesoftwares.com/differences-between-pro-and-lite-versions-of-abandoned-cart-for-woocommerce-plugin/';
 
-                    $message = wp_kses_post ( __( 'Using Abandoned Cart Pro plugin, you can add more merge tags, one-click Cart & Checkout page button, send customised abandoned cart reminder email to specific customers & <strong><a target="_blank" href= "'.$wcal_pro_diff.'">much more</a></strong>. <br>Grab 20% discount on the purchase using ACPRO20 discount code and save $24. Coupon is limited to first 20 customers only. <strong><a target="_blank" href= "'.$wcal_ac_pro_link.'">Purchase now</a></strong>.', 'woocommerce-ac' ) );
+                    $message = wp_kses_post ( __( 'Using Abandoned Cart Pro plugin, you can add more merge tags, one-click Cart & Checkout page button, send customised abandoned cart reminder email to specific customers & <strong><a target="_blank" href= "'.$wcal_pro_diff.'">much more</a></strong>. <br>Grab 20% discount on the purchase using ACPRO20 discount code and save $24. Coupon is limited to first 20 customers only. <strong><a target="_blank" href= "'.$wcal_ac_pro_link.'">Purchase now</a></strong>.', 'woocommerce-abandoned-cart' ) );
 
                     $add_query_arguments = add_query_arg( 'wcal_pro_fourth_notice_ignore', '0' );
                     
@@ -117,7 +117,7 @@ class Wcal_Admin_Notice {
 
                     $wcal_pro_diff = 'https://www.tychesoftwares.com/differences-between-pro-and-lite-versions-of-abandoned-cart-for-woocommerce-plugin/';
 
-                    $message = wp_kses_post ( __( 'Using Abandoned Cart Pro plugin, you can add more merge tags, one-click Cart & Checkout page button, send customised abandoned cart reminder email to specific customers & <strong><a target="_blank" href= "'.$wcal_pro_diff.'">much more</a></strong>. <br>Grab 20% discount on the purchase using ABPRO20 discount code and save $24. Coupon is limited to first 20 customers only. <strong><a target="_blank" href= "'.$wcal_ac_pro_link.'">Purchase now</a></strong>.', 'woocommerce-ac' ) );
+                    $message = wp_kses_post ( __( 'Using Abandoned Cart Pro plugin, you can add more merge tags, one-click Cart & Checkout page button, send customised abandoned cart reminder email to specific customers & <strong><a target="_blank" href= "'.$wcal_pro_diff.'">much more</a></strong>. <br>Grab 20% discount on the purchase using ABPRO20 discount code and save $24. Coupon is limited to first 20 customers only. <strong><a target="_blank" href= "'.$wcal_ac_pro_link.'">Purchase now</a></strong>.', 'woocommerce-abandoned-cart' ) );
 
                     $add_query_arguments = add_query_arg( 'wcal_pro_fourth_notice_ignore', '0' );
                     

--- a/woocommerce-abandoned-cart/includes/wcal_ts_tracking.php
+++ b/woocommerce-abandoned-cart/includes/wcal_ts_tracking.php
@@ -47,10 +47,10 @@ class Wcal_TS_Tracking {
 			<div class="wcal-message wcal-tracker notice notice-info is-dismissible" style="position: relative;">
 				<div style="position: absolute;"><img class="site-logo" src="<?php echo plugins_url(); ?>/woocommerce-abandoned-cart/assets/images/site-logo-new.jpg"></div>
 				<p style="margin: 10px 0 10px 130px; font-size: medium;">
-					<?php print( __( 'Want to help make Abandoned Cart even more awesome? Allow Abandoned Cart to collect non-sensitive diagnostic data and usage information and get 20% off on your next purchase. <a href="https://www.tychesoftwares.com/abandoned-cart-lite-usage-tracking/" target="_blank">Find out more</a>. <br><br>', 'woocommerce-ac' ) ); ?></p>
+					<?php print( __( 'Want to help make Abandoned Cart even more awesome? Allow Abandoned Cart to collect non-sensitive diagnostic data and usage information and get 20% off on your next purchase. <a href="https://www.tychesoftwares.com/abandoned-cart-lite-usage-tracking/" target="_blank">Find out more</a>. <br><br>', 'woocommerce-abandoned-cart' ) ); ?></p>
 				<p class="submit">
-					<a class="button-primary button button-large" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wcal_tracker_optin', 'true' ), 'wcal_tracker_optin', 'wcal_tracker_nonce' ) ); ?>"><?php esc_html_e( 'Allow', 'woocommerce-ac' ); ?></a>
-					<a class="button-secondary button button-large skip"  href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wcal_tracker_optout', 'true' ), 'wcal_tracker_optout', 'wcal_tracker_nonce' ) ); ?>"><?php esc_html_e( 'No thanks', 'woocommerce-ac' ); ?></a>
+					<a class="button-primary button button-large" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wcal_tracker_optin', 'true' ), 'wcal_tracker_optin', 'wcal_tracker_nonce' ) ); ?>"><?php esc_html_e( 'Allow', 'woocommerce-abandoned-cart' ); ?></a>
+					<a class="button-secondary button button-large skip"  href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wcal_tracker_optout', 'true' ), 'wcal_tracker_optout', 'wcal_tracker_nonce' ) ); ?>"><?php esc_html_e( 'No thanks', 'woocommerce-abandoned-cart' ); ?></a>
 				</p>
 			</div>
 		<?php endif;

--- a/woocommerce-abandoned-cart/includes/welcome.php
+++ b/woocommerce-abandoned-cart/includes/welcome.php
@@ -54,8 +54,8 @@ class Wcal_Welcome {
 
 		// About Page
 		add_dashboard_page(
-			sprintf( esc_html__( 'Welcome to Abandoned Cart Lite %s', 'woocommerce-ac' ), $display_version ),
-			esc_html__( 'Welcome to Abandoned Cart Lite', 'woocommerce-ac' ),
+			sprintf( esc_html__( 'Welcome to Abandoned Cart Lite %s', 'woocommerce-abandoned-cart' ), $display_version ),
+			esc_html__( 'Welcome to Abandoned Cart Lite', 'woocommerce-abandoned-cart' ),
 			$this->minimum_capability,
 			'wcal-about',
 			array( $this, 'about_screen' )
@@ -109,19 +109,19 @@ class Wcal_Welcome {
 
             <div class="feature-section clearfix introduction">
 
-                <h3><?php esc_html_e( "Get Started with Abandoned Cart Lite", 'woocommerce-ac' ); ?></h3>
+                <h3><?php esc_html_e( "Get Started with Abandoned Cart Lite", 'woocommerce-abandoned-cart' ); ?></h3>
 
                 <div class="video feature-section-item" style="float:left;padding-right:10px;">
                     <img src="<?php echo WCAL_PLUGIN_URL . '/assets/images/abandoned-cart-lite-email-templates.png' ?>"
-                         alt="<?php esc_attr_e( 'WooCommerce Abandoned Cart Lite', 'woocommerce-ac' ); ?>" style="width:600px;">
+                         alt="<?php esc_attr_e( 'WooCommerce Abandoned Cart Lite', 'woocommerce-abandoned-cart' ); ?>" style="width:600px;">
                 </div>
 
                 <div class="content feature-section-item last-feature">
-                    <h3><?php esc_html_e( 'Activate Email Template', 'woocommerce-ac' ); ?></h3>
+                    <h3><?php esc_html_e( 'Activate Email Template', 'woocommerce-abandoned-cart' ); ?></h3>
 
-                    <p><?php esc_html_e( 'To start sending out abandoned cart notification emails, simply activate the email template from under WooCommerce -> Abandoned Carts -> Email Templates page.', 'woocommerce-ac' ); ?></p>
+                    <p><?php esc_html_e( 'To start sending out abandoned cart notification emails, simply activate the email template from under WooCommerce -> Abandoned Carts -> Email Templates page.', 'woocommerce-abandoned-cart' ); ?></p>
                     <a href="admin.php?page=woocommerce_ac_page&action=emailtemplates" target="_blank" class="button-secondary">
-						<?php esc_html_e( 'Click Here to go to Email Templates page', 'woocommerce-ac' ); ?>
+						<?php esc_html_e( 'Click Here to go to Email Templates page', 'woocommerce-abandoned-cart' ); ?>
                         <span class="dashicons dashicons-external"></span>
                     </a>
                 </div>
@@ -131,22 +131,22 @@ class Wcal_Welcome {
 
             <div class="content">
 
-                <h3><?php esc_html_e( "Know more about Abandoned Cart Pro", 'woocommerce-ac' ); ?></h3>
+                <h3><?php esc_html_e( "Know more about Abandoned Cart Pro", 'woocommerce-abandoned-cart' ); ?></h3>
 
                 <p><?php _e( 'The Abandoned Cart Pro plugin gives you features where you are able to recover more sales compared to the Lite plugin. Here are some notable features the Pro version provides.' ); ?></p>
 
 	            <div class="feature-section clearfix introduction">
 	                <div class="video feature-section-item" style="float:left;padding-right:10px;">
 	                    <img src="https://www.tychesoftwares.com/wp-content/uploads/2017/08/atc_frontend.png"
-	                         alt="<?php esc_attr_e( 'WooCommerce Abandoned Cart Lite', 'woocommerce-ac' ); ?>" style="width:500px;">
+	                         alt="<?php esc_attr_e( 'WooCommerce Abandoned Cart Lite', 'woocommerce-abandoned-cart' ); ?>" style="width:500px;">
 	                </div>
 
 	                <div class="content feature-section-item last-feature">
-	                    <h3><?php esc_html_e( 'Capture Visitor Emails on click of Add to Cart button', 'woocommerce-ac' ); ?></h3>
+	                    <h3><?php esc_html_e( 'Capture Visitor Emails on click of Add to Cart button', 'woocommerce-abandoned-cart' ); ?></h3>
 
-	                    <p><?php esc_html_e( 'The ability to capture the email address early in the order process is very important to reduce cart abandonment by unknown users as well as to be able to recover their carts if they abandon it. This ultimately leads to increase in your store sales.', 'woocommerce-ac' ); ?></p>
+	                    <p><?php esc_html_e( 'The ability to capture the email address early in the order process is very important to reduce cart abandonment by unknown users as well as to be able to recover their carts if they abandon it. This ultimately leads to increase in your store sales.', 'woocommerce-abandoned-cart' ); ?></p>
 	                    <a href="https://www.tychesoftwares.com/capture-guest-user-email-address-before-checkout-page-with-woocommerce-abandoned-cart-pro/?utm_source=wpaboutpage&utm_medium=link&utm_campaign=AbandonedCartLitePlugin" target="_blank" class="button-secondary">
-							<?php esc_html_e( 'Learn More', 'woocommerce-ac' ); ?>
+							<?php esc_html_e( 'Learn More', 'woocommerce-abandoned-cart' ); ?>
 	                        <span class="dashicons dashicons-external"></span>
 	                    </a>
 	                </div>
@@ -155,32 +155,32 @@ class Wcal_Welcome {
 				<div class="feature-section clearfix">
 	                <div class="content feature-section-item">
 
-	                	<h3><?php esc_html_e( 'Set different cut-off times for visitors & logged-in users', 'woocommerce-ac' ); ?></h3>
+	                	<h3><?php esc_html_e( 'Set different cut-off times for visitors & logged-in users', 'woocommerce-abandoned-cart' ); ?></h3>
 
-		                    <p><?php esc_html_e( 'The provision for setting two separate cut-off times for different roles is mainly because sometimes if the store admin wants the visitor carts to be captured earlier than the registered user carts, then these different settings can play an important role.', 'woocommerce-ac' ); ?></p>
+		                    <p><?php esc_html_e( 'The provision for setting two separate cut-off times for different roles is mainly because sometimes if the store admin wants the visitor carts to be captured earlier than the registered user carts, then these different settings can play an important role.', 'woocommerce-abandoned-cart' ); ?></p>
 		                    <a href="https://www.tychesoftwares.com/capturing-abandoned-carts-woocommerce-abandoned-cart-pro-plugin/?utm_source=wpaboutpage&utm_medium=link&utm_campaign=AbandonedCartLitePlugin" target="_blank" class="button-secondary">
-								<?php esc_html_e( 'Learn More', 'woocommerce-ac' ); ?>
+								<?php esc_html_e( 'Learn More', 'woocommerce-abandoned-cart' ); ?>
 		                        <span class="dashicons dashicons-external"></span>
 		                    </a>
 	                </div>
 
 	                <div class="content feature-section-item last-feature">
-	                    <img src="<?php echo WCAL_PLUGIN_URL . 'assets/images/abandon-cart-cut-off-time.png'; ?>" alt="<?php esc_attr_e( 'WooCommerce Abandoned Cart Lite', 'woocommerce-ac' ); ?>" style="width:450px;">
+	                    <img src="<?php echo WCAL_PLUGIN_URL . 'assets/images/abandon-cart-cut-off-time.png'; ?>" alt="<?php esc_attr_e( 'WooCommerce Abandoned Cart Lite', 'woocommerce-abandoned-cart' ); ?>" style="width:450px;">
 	                </div>
 	            </div>
 
        
 	            <div class="feature-section clearfix introduction">
 	                <div class="video feature-section-item" style="float:left;padding-right:10px;">
-	                    <img src="<?php echo WCAL_PLUGIN_URL . 'assets/images/email-templates-send-time.png'; ?>" alt="<?php esc_attr_e( 'WooCommerce Abandoned Cart Lite', 'woocommerce-ac' ); ?>" style="width:450px;">
+	                    <img src="<?php echo WCAL_PLUGIN_URL . 'assets/images/email-templates-send-time.png'; ?>" alt="<?php esc_attr_e( 'WooCommerce Abandoned Cart Lite', 'woocommerce-abandoned-cart' ); ?>" style="width:450px;">
 	                </div>
 
 	                <div class="content feature-section-item last-feature">
-	                    <h3><?php esc_html_e( 'Send abandoned cart recovery email in minutes of cart being abandoned', 'woocommerce-ac' ); ?></h3>
+	                    <h3><?php esc_html_e( 'Send abandoned cart recovery email in minutes of cart being abandoned', 'woocommerce-abandoned-cart' ); ?></h3>
 
-	                    <p><?php esc_html_e( 'The ability to send the abandoned cart recovery email within first few minutes of cart being abandoned is a big advantage. In the Lite plugin, the earliest an email can be sent is after 1 hour. Whereas in the Pro version, the first recovery email gets sent 15 minutes after the cart is abandoned. This increases the recovery chances manifold.', 'woocommerce-ac' ); ?></p>
+	                    <p><?php esc_html_e( 'The ability to send the abandoned cart recovery email within first few minutes of cart being abandoned is a big advantage. In the Lite plugin, the earliest an email can be sent is after 1 hour. Whereas in the Pro version, the first recovery email gets sent 15 minutes after the cart is abandoned. This increases the recovery chances manifold.', 'woocommerce-abandoned-cart' ); ?></p>
 	                    <a href="https://www.tychesoftwares.com/understanding-the-default-email-templates-of-abandoned-cart-pro-for-woocommerce-plugin/?utm_source=wpaboutpage&utm_medium=link&utm_campaign=AbandonedCartLitePlugin" target="_blank" class="button-secondary">
-							<?php esc_html_e( 'Learn More', 'woocommerce-ac' ); ?>
+							<?php esc_html_e( 'Learn More', 'woocommerce-abandoned-cart' ); ?>
 	                        <span class="dashicons dashicons-external"></span>
 	                    </a>
 	                </div>
@@ -189,22 +189,22 @@ class Wcal_Welcome {
 				<div class="feature-section clearfix">
 	                <div class="content feature-section-item">
 
-	                	<h3><?php esc_html_e( 'Full range of merge tags that allow you to personalize the abandoned cart email', 'woocommerce-ac' ); ?></h3>
+	                	<h3><?php esc_html_e( 'Full range of merge tags that allow you to personalize the abandoned cart email', 'woocommerce-abandoned-cart' ); ?></h3>
 
-		                    <p><?php esc_html_e( 'The Lite version has only 3 merge tags available to personalize the abandoned cart recovery emails. The Pro version instead, has 20 different merge tags that can be used effectively to personalize each email that gets sent out to the customers for recovering their abandoned carts.', 'woocommerce-ac' ); ?></p>
+		                    <p><?php esc_html_e( 'The Lite version has only 3 merge tags available to personalize the abandoned cart recovery emails. The Pro version instead, has 20 different merge tags that can be used effectively to personalize each email that gets sent out to the customers for recovering their abandoned carts.', 'woocommerce-abandoned-cart' ); ?></p>
 		                    <a href="https://www.tychesoftwares.com/understanding-the-default-email-templates-of-abandoned-cart-pro-for-woocommerce-plugin/?utm_source=wpaboutpage&utm_medium=link&utm_campaign=AbandonedCartLitePlugin" target="_blank" class="button-secondary">
-								<?php esc_html_e( 'Learn More', 'woocommerce-ac' ); ?>
+								<?php esc_html_e( 'Learn More', 'woocommerce-abandoned-cart' ); ?>
 		                        <span class="dashicons dashicons-external"></span>
 		                    </a>
 	                </div>
 
 	                <div class="content feature-section-item last-feature">
-	                    <img src="https://www.tychesoftwares.com/wp-content/uploads/2016/10/drop-down-of-AC.png" alt="<?php esc_attr_e( 'WooCommerce Abandoned Cart Lite', 'woocommerce-ac' ); ?>" style="width:450px;">
+	                    <img src="https://www.tychesoftwares.com/wp-content/uploads/2016/10/drop-down-of-AC.png" alt="<?php esc_attr_e( 'WooCommerce Abandoned Cart Lite', 'woocommerce-abandoned-cart' ); ?>" style="width:450px;">
 	                </div>
 	            </div>
 
                 <a href="https://www.tychesoftwares.com/differences-between-pro-and-lite-versions-of-abandoned-cart-for-woocommerce-plugin/?utm_source=wpaboutpage&utm_medium=link&utm_campaign=AbandonedCartLitePlugin" target="_blank" class="button-secondary">
-					<?php esc_html_e( 'View full list of differences between Lite & Pro plugin', 'woocommerce-ac' ); ?>
+					<?php esc_html_e( 'View full list of differences between Lite & Pro plugin', 'woocommerce-abandoned-cart' ); ?>
                     <span class="dashicons dashicons-external"></span>
                 </a>
             </div>
@@ -213,11 +213,11 @@ class Wcal_Welcome {
 
                 <div class="content feature-section-item">
 
-                    <h3><?php esc_html_e( 'Getting to Know Tyche Softwares', 'woocommerce-ac' ); ?></h3>
+                    <h3><?php esc_html_e( 'Getting to Know Tyche Softwares', 'woocommerce-abandoned-cart' ); ?></h3>
 
                     <ul class="ul-disc">
-                        <li><a href="https://tychesoftwares.com/?utm_source=wpaboutpage&utm_medium=link&utm_campaign=AbandonedCartLitePlugin" target="_blank"><?php esc_html_e( 'Visit the Tyche Softwares Website', 'woocommerce-ac' ); ?></a></li>
-                        <li><a href="https://tychesoftwares.com/premium-plugins/?utm_source=wpaboutpage&utm_medium=link&utm_campaign=AbandonedCartLitePlugin" target="_blank"><?php esc_html_e( 'View all Premium Plugins', 'woocommerce-ac' ); ?></a>
+                        <li><a href="https://tychesoftwares.com/?utm_source=wpaboutpage&utm_medium=link&utm_campaign=AbandonedCartLitePlugin" target="_blank"><?php esc_html_e( 'Visit the Tyche Softwares Website', 'woocommerce-abandoned-cart' ); ?></a></li>
+                        <li><a href="https://tychesoftwares.com/premium-plugins/?utm_source=wpaboutpage&utm_medium=link&utm_campaign=AbandonedCartLitePlugin" target="_blank"><?php esc_html_e( 'View all Premium Plugins', 'woocommerce-abandoned-cart' ); ?></a>
                         <ul class="ul-disc">
                         	<li><a href="https://www.tychesoftwares.com/store/premium-plugins/woocommerce-abandoned-cart-pro/?utm_source=wpaboutpage&utm_medium=link&utm_campaign=AbandonedCartLitePlugin" target="_blank">Abandoned Cart Pro Plugin for WooCommerce</a></li>
                         	<li><a href="https://www.tychesoftwares.com/store/premium-plugins/woocommerce-booking-plugin/?utm_source=wpaboutpage&utm_medium=link&utm_campaign=AbandonedCartLitePlugin" target="_blank">Booking & Appointment Plugin for WooCommerce</a></li>
@@ -226,7 +226,7 @@ class Wcal_Welcome {
                         	<li><a href="https://www.tychesoftwares.com/store/premium-plugins/deposits-for-woocommerce/?utm_source=wpaboutpage&utm_medium=link&utm_campaign=AbandonedCartLitePlugin" target="_blank">Deposits for WooCommerce</a></li>
                         </ul>
                         </li>
-                        <li><a href="https://tychesoftwares.com/about/?utm_source=wpaboutpage&utm_medium=link&utm_campaign=AbandonedCartLitePlugin" target="_blank"><?php esc_html_e( 'Meet the team', 'woocommerce-ac' ); ?></a></li>
+                        <li><a href="https://tychesoftwares.com/about/?utm_source=wpaboutpage&utm_medium=link&utm_campaign=AbandonedCartLitePlugin" target="_blank"><?php esc_html_e( 'Meet the team', 'woocommerce-abandoned-cart' ); ?></a></li>
                     </ul>
 
                 </div>
@@ -234,7 +234,7 @@ class Wcal_Welcome {
 
                 <div class="content feature-section-item">
 
-                    <h3><?php esc_html_e( 'Current Offers', 'woocommerce-ac' ); ?></h3>
+                    <h3><?php esc_html_e( 'Current Offers', 'woocommerce-abandoned-cart' ); ?></h3>
 
                     <p>Buy all our <a href="https://tychesoftwares.com/premium-plugins/?utm_source=wpaboutpage&utm_medium=link&utm_campaign=AbandonedCartLitePlugin" target="_blank">premium plugins</a> at 30% off till 31st December 2017</p>
 

--- a/woocommerce-abandoned-cart/woocommerce-ac.php
+++ b/woocommerce-abandoned-cart/woocommerce-ac.php
@@ -6,7 +6,7 @@
 * Version: 4.6
 * Author: Tyche Softwares
 * Author URI: http://www.tychesoftwares.com/
-* Text Domain: woocommerce-ac
+* Text Domain: woocommerce-abandoned-cart
 * Domain Path: /i18n/languages/
 * Requires PHP: 5.6
 * WC requires at least: 3.0.0
@@ -54,7 +54,7 @@ if ( ! wp_next_scheduled( 'woocommerce_ac_send_email_action' ) ) {
 function wcal_add_tracking_cron_schedule( $schedules ) {
     $schedules[ 'daily_once' ] = array(
         'interval' => 604800,  // one week in seconds
-        'display'  => __( 'Once in a Week', 'woocommerce-ac' )
+        'display'  => __( 'Once in a Week', 'woocommerce-abandoned-cart' )
     );
     return $schedules;
 }
@@ -310,7 +310,7 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
         public static function wcal_wc_disabled_notice() {
                 
             $class = 'notice notice-error is-dismissible';
-            $message = __( 'Abandoned Cart Lite for WooCommerce requires WooCommerce installed and activate.', 'woocommerce-ac' );
+            $message = __( 'Abandoned Cart Lite for WooCommerce requires WooCommerce installed and activate.', 'woocommerce-abandoned-cart' );
                 
             printf( '<div class="%1$s"><p>%2$s</p></div>', $class, $message );
         }
@@ -541,7 +541,7 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                     $query_order = "UPDATE $wcal_ac_table_name SET recovered_cart = '" . $order_id . "', cart_ignored = '1' WHERE id = '".$get_abandoned_id_of_order."' ";
                     $wpdb->query( $query_order );
         
-                    $order->add_order_note( __( 'This order was abandoned & subsequently recovered.', 'woocommerce-ac' ) );
+                    $order->add_order_note( __( 'This order was abandoned & subsequently recovered.', 'woocommerce-abandoned-cart' ) );
 
                     delete_post_meta( $order_id,  'wcal_recover_order_placed',         $get_abandoned_id_of_order );
                     delete_post_meta( $order_id , 'wcal_recover_order_placed_sent_id', $get_sent_email_id_of_order );
@@ -581,7 +581,7 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
         public function wcal_preview_emails() {
             global $woocommerce;
             if( isset( $_GET['wcal_preview_woocommerce_mail'] ) ) {
-                if( !wp_verify_nonce( $_REQUEST['_wpnonce'], 'woocommerce-ac' ) ) {
+                if( !wp_verify_nonce( $_REQUEST['_wpnonce'], 'woocommerce-abandoned-cart' ) ) {
                     die( 'Security check' );
                 }
                 $message = '';
@@ -593,13 +593,13 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                     include( 'views/wcal-wc-email-template-preview.php' );
                     $mailer        = WC()->mailer();
                     $message       = ob_get_clean();
-                    $email_heading = __( 'HTML Email Template', 'woocommerce-ac' );
+                    $email_heading = __( 'HTML Email Template', 'woocommerce-abandoned-cart' );
                     $message       =  $mailer->wrap_message( $email_heading, $message );
                 } else {
                     // load the mailer class
                     $mailer        = WC()->mailer(); 
                     // get the preview email subject
-                    $email_heading = __( 'Abandoned cart Email Template', 'woocommerce-ac' );       
+                    $email_heading = __( 'Abandoned cart Email Template', 'woocommerce-abandoned-cart' );       
                     // get the preview email content
                     ob_start();
                     include( 'views/wcal-wc-email-template-preview.php' );
@@ -614,7 +614,7 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             }
         
             if ( isset( $_GET['wcal_preview_mail'] ) ) {
-                if ( ! wp_verify_nonce( $_REQUEST['_wpnonce'], 'woocommerce-ac' ) ) {
+                if ( ! wp_verify_nonce( $_REQUEST['_wpnonce'], 'woocommerce-abandoned-cart' ) ) {
                     die( 'Security check' );
                 }
                 // get the preview email content
@@ -629,7 +629,12 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
 
         // Language Translation
         function  wcal_update_po_file() {
-            $domain = 'woocommerce-ac';
+            /*
+            * Due to the introduction of language packs through translate.wordpress.org, loading our textdomain is complex.
+            *
+            * In v4.8, our textdomain changed from "woocommerce-ac" to "woocommerce-abandoned-cart".
+            */
+            $domain = 'woocommerce-abandoned-cart';
             $locale = apply_filters( 'plugin_locale', get_locale(), $domain );
             if ( $loaded = load_textdomain( $domain, trailingslashit( WP_LANG_DIR ) . $domain . '-' . $locale . '.mo' ) ) {
                 return $loaded;
@@ -780,36 +785,36 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             // First, we register a section. This is necessary since all future options must belong to a
             add_settings_section(
                 'ac_lite_general_settings_section',         // ID used to identify this section and with which to register options
-                __( 'Settings', 'woocommerce-ac' ),                  // Title to be displayed on the administration page
+                __( 'Settings', 'woocommerce-abandoned-cart' ),                  // Title to be displayed on the administration page
                 array($this, 'ac_lite_general_options_callback' ), // Callback used to render the description of the section
                 'woocommerce_ac_page'     // Page on which to add this section of options
             );
         
             add_settings_field(
                 'ac_lite_cart_abandoned_time',
-                __( 'Cart abandoned cut-off time', 'woocommerce-ac' ),
+                __( 'Cart abandoned cut-off time', 'woocommerce-abandoned-cart' ),
                 array( $this, 'ac_lite_cart_abandoned_time_callback' ),
                 'woocommerce_ac_page',
                 'ac_lite_general_settings_section',
-                array( __( 'Consider cart abandoned after X minutes of item being added to cart & order not placed.', 'woocommerce-ac' ) )
+                array( __( 'Consider cart abandoned after X minutes of item being added to cart & order not placed.', 'woocommerce-abandoned-cart' ) )
             );
             
             add_settings_field(
                 'ac_lite_email_admin_on_recovery',
-                __( 'Email admin On Order Recovery', 'woocommerce-ac' ),
+                __( 'Email admin On Order Recovery', 'woocommerce-abandoned-cart' ),
                 array( $this, 'ac_lite_email_admin_on_recovery' ),
                 'woocommerce_ac_page',
                 'ac_lite_general_settings_section',
-                array( __( 'Sends email to Admin if an Abandoned Cart Order is recovered.', 'woocommerce-ac' ) )
+                array( __( 'Sends email to Admin if an Abandoned Cart Order is recovered.', 'woocommerce-abandoned-cart' ) )
             );
             
             add_settings_field(
             'ac_lite_track_guest_cart_from_cart_page',
-            __( 'Start tracking from Cart Page', 'woocommerce-ac' ),
+            __( 'Start tracking from Cart Page', 'woocommerce-abandoned-cart' ),
             array( $this, 'wcal_track_guest_cart_from_cart_page_callback' ),
             'woocommerce_ac_page',
             'ac_lite_general_settings_section',
-            array( __( 'Enable tracking of abandoned products & carts even if customer does not visit the checkout page or does not enter any details on the checkout page like Name or Email. Tracking will begin as soon as a visitor adds a product to their cart and visits the cart page.', 'woocommerce-ac' ) )
+            array( __( 'Enable tracking of abandoned products & carts even if customer does not visit the checkout page or does not enter any details on the checkout page like Name or Email. Tracking will begin as soon as a visitor adds a product to their cart and visits the cart page.', 'woocommerce-abandoned-cart' ) )
             );
             /*
              * New section for the Adding the abandoned cart setting.
@@ -818,36 +823,36 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             
             add_settings_section(
             'ac_email_settings_section',           // ID used to identify this section and with which to register options
-            __( 'Settings for abandoned cart recovery emails', 'woocommerce-ac' ),      // Title to be displayed on the administration page
+            __( 'Settings for abandoned cart recovery emails', 'woocommerce-abandoned-cart' ),      // Title to be displayed on the administration page
             array($this, 'wcal_email_callback' ),// Callback used to render the description of the section
             'woocommerce_ac_email_page'     // Page on which to add this section of options
             );
             
             add_settings_field(
             'wcal_from_name',
-            __( '"From" Name', 'woocommerce-ac'  ),
+            __( '"From" Name', 'woocommerce-abandoned-cart'  ),
             array( $this, 'wcal_from_name_callback' ),
             'woocommerce_ac_email_page',
             'ac_email_settings_section',
-            array( 'Enter the name that should appear in the email sent.', 'woocommerce-ac' )
+            array( 'Enter the name that should appear in the email sent.', 'woocommerce-abandoned-cart' )
             );
             
             add_settings_field(
             'wcal_from_email',
-            __( '"From" Address', 'woocommerce-ac'  ),
+            __( '"From" Address', 'woocommerce-abandoned-cart'  ),
             array( $this, 'wcal_from_email_callback' ),
             'woocommerce_ac_email_page',
             'ac_email_settings_section',
-            array( 'Email address from which the reminder emails should be sent.', 'woocommerce-ac' )
+            array( 'Email address from which the reminder emails should be sent.', 'woocommerce-abandoned-cart' )
             );
             
             add_settings_field(
             'wcal_reply_email',
-            __( 'Send Reply Emails to', 'woocommerce-ac'  ),
+            __( 'Send Reply Emails to', 'woocommerce-abandoned-cart'  ),
             array( $this, 'wcal_reply_email_callback' ),
             'woocommerce_ac_email_page',
             'ac_email_settings_section',
-            array( 'When a contact receives your email and clicks reply, which email address should that reply be sent to?', 'woocommerce-ac' )
+            array( 'When a contact receives your email and clicks reply, which email address should that reply be sent to?', 'woocommerce-abandoned-cart' )
             );
             
             // Finally, we register the fields with WordPress
@@ -913,7 +918,7 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             if ( $input != '' && ( is_numeric( $input) && $input > 0  ) ) {
                 $output = stripslashes( $input) ;
             } else {
-                add_settings_error( 'ac_lite_cart_abandoned_time', 'error found', __( 'Abandoned cart cut off time should be numeric and has to be greater than 0.', 'woocommerce-ac' ) );
+                add_settings_error( 'ac_lite_cart_abandoned_time', 'error found', __( 'Abandoned cart cut off time should be numeric and has to be greater than 0.', 'woocommerce-abandoned-cart' ) );
             }
             return $output;
         }
@@ -1177,9 +1182,9 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                     
                     if ( 'checkout' == $created_via && 'yes' != $recovered_email_sent && true === $wcal_check_order_is_recovered ) { // indicates cart is abandoned
                         $order          = new WC_Order( $order_id );
-                        $email_heading  = __( 'New Customer Order - Recovered', 'woocommerce-ac' );
+                        $email_heading  = __( 'New Customer Order - Recovered', 'woocommerce-abandoned-cart' );
                         $blogname       = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
-                        $email_subject  = "New Customer Order - Recovered";
+                        $email_subject  = __( 'New Customer Order - Recovered', 'woocommerce-abandoned-cart' );
                         $user_email     = get_option( 'admin_email' );
                         $headers[]      = "From: Admin <".$user_email.">";
                         $headers[]      = "Content-Type: text/html";
@@ -1224,9 +1229,9 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                 $created_via                   = get_post_meta( $order_id, '_created_via', true ); 
                 $wcal_check_order_is_recovered = woocommerce_abandon_cart_lite::wcal_check_order_is_recovered( $order_id );              
                 if ( 'checkout' == $created_via && 'yes' != $recovered_email_sent && true === $wcal_check_order_is_recovered ) { // indicates cart is abandoned                           
-                    $email_heading = __( 'New Customer Order - Recovered', 'woocommerce-ac' );          
+                    $email_heading = __( 'New Customer Order - Recovered', 'woocommerce-abandoned-cart' );          
                     $blogname      = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
-                    $email_subject = "New Customer Order - Recovered";
+                    $email_subject = __( 'New Customer Order - Recovered', 'woocommerce-abandoned-cart' ); 
                     $user_email    = get_option( 'admin_email' );
                     $headers[]     = "From: Admin <".$user_email.">";
                     $headers[]     = "Content-Type: text/html";
@@ -1263,7 +1268,7 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                  
         // Add a submenu page.
         function wcal_admin_menu() {
-            $page = add_submenu_page ( 'woocommerce', __( 'Abandoned Carts', 'woocommerce-ac' ), __( 'Abandoned Carts', 'woocommerce-ac' ), 'manage_woocommerce', 'woocommerce_ac_page', array( &$this, 'wcal_menu_page' ) );
+            $page = add_submenu_page ( 'woocommerce', __( 'Abandoned Carts', 'woocommerce-abandoned-cart' ), __( 'Abandoned Carts', 'woocommerce-abandoned-cart' ), 'manage_woocommerce', 'woocommerce_ac_page', array( &$this, 'wcal_menu_page' ) );
         }
             
         // Capture the cart and insert the information of the cart into DataBase
@@ -1758,7 +1763,7 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                     WHERE id = '".$get_abandoned_id_of_order."' ";
                 $wpdb->query( $query_order );
             
-                $order->add_order_note( __( 'This order was abandoned & subsequently recovered.', 'woocommerce-ac' ) );
+                $order->add_order_note( __( 'This order was abandoned & subsequently recovered.', 'woocommerce-abandoned-cart' ) );
                  
                 delete_post_meta( $order_id, 'wcal_recover_order_placed', $get_abandoned_id_of_order );
                 delete_post_meta( $order_id , 'wcal_recover_order_placed_sent_id', $get_sent_email_id_of_order );
@@ -1915,11 +1920,11 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             <div style="background-image: url('<?php echo plugins_url(); ?>/woocommerce-abandoned-cart/assets/images/ac_tab_icon.png') !important;" class="icon32"><br>
             </div>                      
             <h2 class="nav-tab-wrapper woo-nav-tab-wrapper">
-                <a href="admin.php?page=woocommerce_ac_page&action=listcart" class="nav-tab <?php if (isset($active_listcart)) echo $active_listcart; ?>"> <?php _e( 'Abandoned Orders', 'woocommerce-ac' );?> </a>
-                <a href="admin.php?page=woocommerce_ac_page&action=emailtemplates" class="nav-tab <?php if (isset($active_emailtemplates)) echo $active_emailtemplates; ?>"> <?php _e( 'Email Templates', 'woocommerce-ac' );?> </a>
-                <a href="admin.php?page=woocommerce_ac_page&action=emailsettings" class="nav-tab <?php if (isset($active_settings)) echo $active_settings; ?>"> <?php _e( 'Settings', 'woocommerce-ac' );?> </a>
-                <a href="admin.php?page=woocommerce_ac_page&action=stats" class="nav-tab <?php if (isset($active_stats)) echo $active_stats; ?>"> <?php _e( 'Recovered Orders', 'woocommerce-ac' );?> </a>
-                <a href="admin.php?page=woocommerce_ac_page&action=report" class="nav-tab <?php if( isset( $active_report ) ) echo $active_report; ?>"> <?php _e( 'Product Report', 'woocommerce-ac' );?> </a>
+                <a href="admin.php?page=woocommerce_ac_page&action=listcart" class="nav-tab <?php if (isset($active_listcart)) echo $active_listcart; ?>"> <?php _e( 'Abandoned Orders', 'woocommerce-abandoned-cart' );?> </a>
+                <a href="admin.php?page=woocommerce_ac_page&action=emailtemplates" class="nav-tab <?php if (isset($active_emailtemplates)) echo $active_emailtemplates; ?>"> <?php _e( 'Email Templates', 'woocommerce-abandoned-cart' );?> </a>
+                <a href="admin.php?page=woocommerce_ac_page&action=emailsettings" class="nav-tab <?php if (isset($active_settings)) echo $active_settings; ?>"> <?php _e( 'Settings', 'woocommerce-abandoned-cart' );?> </a>
+                <a href="admin.php?page=woocommerce_ac_page&action=stats" class="nav-tab <?php if (isset($active_stats)) echo $active_stats; ?>"> <?php _e( 'Recovered Orders', 'woocommerce-abandoned-cart' );?> </a>
+                <a href="admin.php?page=woocommerce_ac_page&action=report" class="nav-tab <?php if( isset( $active_report ) ) echo $active_report; ?>"> <?php _e( 'Product Report', 'woocommerce-abandoned-cart' );?> </a>
             </h2>
             <?php
         }
@@ -2014,11 +2019,11 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                 global $wpdb;                   
                 // Check the user capabilities
                 if ( !current_user_can( 'manage_woocommerce' ) ) {    
-                    wp_die( __( 'You do not have sufficient permissions to access this page.', 'woocommerce-ac' ) );
+                    wp_die( __( 'You do not have sufficient permissions to access this page.', 'woocommerce-abandoned-cart' ) );
                 }           
                 ?>
                 <div class="wrap">    
-                    <h2><?php _e( 'WooCommerce - Abandon Cart Lite', 'woocommerce-ac' ); ?></h2>
+                    <h2><?php _e( 'WooCommerce - Abandon Cart Lite', 'woocommerce-abandoned-cart' ); ?></h2>
                 <?php 
                 
                  if ( isset( $_GET['action'] ) ) {
@@ -2066,18 +2071,18 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
              
                 if ( isset( $_GET['wcal_deleted'] ) && 'YES' == $_GET['wcal_deleted'] ) { ?>
                      <div id="message" class="updated fade">
-                       <p><strong><?php _e( 'The Abandoned cart has been successfully deleted.', 'woocommerce-ac' ); ?></strong></p>
+                       <p><strong><?php _e( 'The Abandoned cart has been successfully deleted.', 'woocommerce-abandoned-cart' ); ?></strong></p>
                      </div>
           <?php }    
                  if ( isset( $_GET ['wcal_template_deleted'] ) && 'YES' == $_GET['wcal_template_deleted'] ) { ?>
                     <div id="message" class="updated fade">
-                        <p><strong><?php _e( 'The Template has been successfully deleted.', 'woocommerce-ac' ); ?></strong></p>
+                        <p><strong><?php _e( 'The Template has been successfully deleted.', 'woocommerce-abandoned-cart' ); ?></strong></p>
                     </div>
            <?php }            
                  if ( $action == 'emailsettings' ) {
                  // Save the field values
                     ?>
-                    <p><?php _e( 'Change settings for sending email notifications to Customers, to Admin etc.', 'woocommerce-ac' ); ?></p>
+                    <p><?php _e( 'Change settings for sending email notifications to Customers, to Admin etc.', 'woocommerce-abandoned-cart' ); ?></p>
                     <div id="content">
                     <?php 
                         $wcal_general_settings_class = $wcal_email_setting = "";
@@ -2096,10 +2101,10 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                         ?>
                         <ul class="subsubsub" id="wcal_general_settings_list">
                             <li>
-                                <a href="admin.php?page=woocommerce_ac_page&action=emailsettings&wcal_section=wcal_general_settings" class="<?php echo $wcal_general_settings_class; ?>"><?php _e( 'General Settings', 'woocommerce-ac' );?> </a> |
+                                <a href="admin.php?page=woocommerce_ac_page&action=emailsettings&wcal_section=wcal_general_settings" class="<?php echo $wcal_general_settings_class; ?>"><?php _e( 'General Settings', 'woocommerce-abandoned-cart' );?> </a> |
                             </li>
                                <li>
-                                <a href="admin.php?page=woocommerce_ac_page&action=emailsettings&wcal_section=wcal_email_settings" class="<?php echo $wcal_email_setting; ?>"><?php _e( 'Email Sending Settings', 'woocommerce-ac' );?> </a> 
+                                <a href="admin.php?page=woocommerce_ac_page&action=emailsettings&wcal_section=wcal_email_settings" class="<?php echo $wcal_email_setting; ?>"><?php _e( 'Email Sending Settings', 'woocommerce-abandoned-cart' );?> </a> 
                             </li>
                             
                         </ul>
@@ -2129,7 +2134,7 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                   <?php 
                   } elseif ( $action == 'listcart' || '' == $action || '-1' == $action || '-1' == $action_two ) {
                   ?>    
-                        <p> <?php _e( 'The list below shows all Abandoned Carts which have remained in cart for a time higher than the "Cart abandoned cut-off time" setting.', 'woocommerce-ac' );?> </p>
+                        <p> <?php _e( 'The list below shows all Abandoned Carts which have remained in cart for a time higher than the "Cart abandoned cut-off time" setting.', 'woocommerce-abandoned-cart' );?> </p>
                         <?php
                         $get_all_abandoned_count      = wcal_common::wcal_get_abandoned_order_count( 'wcal_all_abandoned' );
                         $get_registered_user_ac_count = wcal_common::wcal_get_abandoned_order_count( 'wcal_all_registered' );
@@ -2171,24 +2176,24 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                         ?>
                         <ul class="subsubsub" id="wcal_recovered_orders_list">
                             <li>
-                                <a href="admin.php?page=woocommerce_ac_page&action=listcart&wcal_section=wcal_all_abandoned" class="<?php echo $wcal_all_abandoned_carts; ?>"><?php _e( "All ", 'woocommerce-ac' ) ;?> <span class = "count" > <?php echo "( $get_all_abandoned_count )" ?> </span></a> 
+                                <a href="admin.php?page=woocommerce_ac_page&action=listcart&wcal_section=wcal_all_abandoned" class="<?php echo $wcal_all_abandoned_carts; ?>"><?php _e( "All ", 'woocommerce-abandoned-cart' ) ;?> <span class = "count" > <?php echo "( $get_all_abandoned_count )" ?> </span></a> 
                             </li>
     
                             <?php if ($get_registered_user_ac_count > 0 ) { ?>
                             <li>
-                                | <a href="admin.php?page=woocommerce_ac_page&action=listcart&wcal_section=wcal_all_registered" class="<?php echo $wcal_all_registered; ?>"><?php _e( " Registered $wcal_user_reg_text ", 'woocommerce-ac' ) ;?> <span class = "count" > <?php echo "( $get_registered_user_ac_count )" ?> </span></a> 
+                                | <a href="admin.php?page=woocommerce_ac_page&action=listcart&wcal_section=wcal_all_registered" class="<?php echo $wcal_all_registered; ?>"><?php printf( __( 'Registered %s', 'woocommerce-abandoned-cart' ), $wcal_user_reg_text ); ?> <span class = "count" > <?php echo "( $get_registered_user_ac_count )" ?> </span></a> 
                             </li>
                             <?php } ?>
     
                             <?php if ($get_guest_user_ac_count > 0 ) { ?>
                             <li>
-                                | <a href="admin.php?page=woocommerce_ac_page&action=listcart&wcal_section=wcal_all_guest" class="<?php echo $wcal_all_guest; ?>"><?php _e( " Guest $wcal_user_gus_text ", 'woocommerce-ac' ) ;?> <span class = "count" > <?php echo "( $get_guest_user_ac_count )" ?> </span></a> 
+                                | <a href="admin.php?page=woocommerce_ac_page&action=listcart&wcal_section=wcal_all_guest" class="<?php echo $wcal_all_guest; ?>"><?php printf( __( 'Guest %s', 'woocommerce-abandoned-cart' ), $wcal_user_gus_text ); ?> <span class = "count" > <?php echo "( $get_guest_user_ac_count )" ?> </span></a> 
                             </li>
                             <?php } ?>
     
                             <?php if ($get_visitor_user_ac_count > 0 ) { ?>
                             <li>
-                                | <a href="admin.php?page=woocommerce_ac_page&action=listcart&wcal_section=wcal_all_visitor" class="<?php echo $wcal_all_visitor; ?>"><?php _e( " Carts without Customer Details ", 'woocommerce-ac' ) ;?> <span class = "count" > <?php echo "( $get_visitor_user_ac_count )" ?> </span></a> 
+                                | <a href="admin.php?page=woocommerce_ac_page&action=listcart&wcal_section=wcal_all_visitor" class="<?php echo $wcal_all_visitor; ?>"><?php _e( "Carts without Customer Details", 'woocommerce-abandoned-cart' ); ?> <span class = "count" > <?php echo "( $get_visitor_user_ac_count )" ?> </span></a> 
                             </li>
                             <?php } ?>
                         </ul>
@@ -2209,7 +2214,7 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                         <?php 
                   } elseif ( $action == 'emailtemplates' && ( $mode != 'edittemplate' && $mode != 'addnewtemplate' ) ) {
                         ?>                                                  
-                        <p> <?php _e( 'Add email templates at different intervals to maximize the possibility of recovering your abandoned carts.', 'woocommerce-ac' );?> </p>
+                        <p> <?php _e( 'Add email templates at different intervals to maximize the possibility of recovering your abandoned carts.', 'woocommerce-abandoned-cart' );?> </p>
                         <?php                       
                         // Save the field values
                         $insert_template_successfuly = $update_template_successfuly = ''; 
@@ -2327,7 +2332,7 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                             <div id="message" class="updated fade">
                                 <p>
                                     <strong>
-                                        <?php _e( 'The Email Template has been successfully added.', 'woocommerce-ac' ); ?>
+                                        <?php _e( 'The Email Template has been successfully added.', 'woocommerce-abandoned-cart' ); ?>
                                     </strong>
                                 </p>
                             </div>
@@ -2336,7 +2341,7 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                 <div id="message" class="error fade">
                                     <p>
                                         <strong>
-                                            <?php _e( ' There was a problem adding the email template. Please contact the plugin author via <a href= "https://wordpress.org/support/plugin/woocommerce-abandoned-cart">support forum</a>.', 'woocommerce-ac' ); ?>
+                                            <?php _e( 'There was a problem adding the email template. Please contact the plugin author via <a href= "https://wordpress.org/support/plugin/woocommerce-abandoned-cart">support forum</a>.', 'woocommerce-abandoned-cart' ); ?>
                                         </strong>
                                     </p>
                                 </div>
@@ -2347,7 +2352,7 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                 <div id="message" class="updated fade">
                                     <p>
                                         <strong>
-                                            <?php _e( 'The Email Template has been successfully updated.', 'woocommerce-ac' ); ?>
+                                            <?php _e( 'The Email Template has been successfully updated.', 'woocommerce-abandoned-cart' ); ?>
                                         </strong>
                                     </p>
                                 </div>
@@ -2356,7 +2361,7 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                     <div id="message" class="error fade">
                                         <p>
                                             <strong>
-                                                <?php _e( ' There was a problem updating the email template. Please contact the plugin author via <a href= "https://wordpress.org/support/plugin/woocommerce-abandoned-cart">support forum</a>.', 'woocommerce-ac' ); ?>
+                                                <?php _e( 'There was a problem updating the email template. Please contact the plugin author via <a href= "https://wordpress.org/support/plugin/woocommerce-abandoned-cart">support forum</a>.', 'woocommerce-abandoned-cart' ); ?>
                                             </strong>
                                         </p>
                                     </div>
@@ -2365,7 +2370,7 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                         ?>
                         <div class="tablenav">
                             <p style="float:left;">
-                               <a cursor: pointer; href="<?php echo "admin.php?page=woocommerce_ac_page&action=emailtemplates&mode=addnewtemplate"; ?>" class="button-secondary"><?php _e( 'Add New Template', 'woocommerce-ac' ); ?>
+                               <a cursor: pointer; href="<?php echo "admin.php?page=woocommerce_ac_page&action=emailtemplates&mode=addnewtemplate"; ?>" class="button-secondary"><?php _e( 'Add New Template', 'woocommerce-abandoned-cart' ); ?>
                                </a>                           
                             </p>
                     
@@ -2442,7 +2447,7 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                         }
                         if ($duration_range == "") $duration_range = "last_seven";
                         
-                            _e( 'The Report below shows how many Abandoned Carts we were able to recover for you by sending automatic emails to     encourage shoppers.', 'woocommerce-ac');
+                            _e( 'The Report below shows how many Abandoned Carts we were able to recover for you by sending automatic emails to encourage shoppers.', 'woocommerce-abandoned-cart');
                         ?>
                         <div id="recovered_stats" class="postbox" style="display:block">
                             <div class="inside">
@@ -2491,35 +2496,35 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                         $end_date_range = $date_sett['end_date'];
                                     }
                                     ?>                       
-                                    <label class="start_label" for="start_day"> <?php _e( 'Start Date:', 'woocommerce-ac' ); ?> </label>
+                                    <label class="start_label" for="start_day"> <?php _e( 'Start Date:', 'woocommerce-abandoned-cart' ); ?> </label>
                                     <input type="text" id="start_date" name="start_date" readonly="readonly" value="<?php echo $start_date_range; ?>"/>     
-                                    <label class="end_label" for="end_day"> <?php _e( 'End Date:', 'woocommerce-ac' ); ?> </label>
+                                    <label class="end_label" for="end_day"> <?php _e( 'End Date:', 'woocommerce-abandoned-cart' ); ?> </label>
                                     <input type="text" id="end_date" name="end_date" readonly="readonly" value="<?php echo $end_date_range; ?>"/>  
-                                    <input type="submit" name="Submit" class="button-primary" value="<?php esc_attr_e( 'Go', 'woocommerce-ac' ); ?>"  />
+                                    <input type="submit" name="Submit" class="button-primary" value="<?php esc_attr_e( 'Go', 'woocommerce-abandoned-cart' ); ?>"  />
                                 </form>
                             </div>
                         </div>
                         <div id="recovered_stats" class="postbox" style="display:block">
                             <div class="inside" >
-                                <p style="font-size: 15px"><?php  _e( 'During the selected range ', 'woocommerce-ac' ); ?>
+                                <p style="font-size: 15px"><?php _e( 'During the selected range ', 'woocommerce-abandoned-cart' ); ?>
                                     <strong>
                                         <?php $count = $wcal_recover_orders_list->total_abandoned_cart_count; 
                                               echo $count; ?> 
                                     </strong>
-                                    <?php _e( 'carts totaling', 'woocommerce-ac' ); ?> 
+                                    <?php _e( 'carts totaling', 'woocommerce-abandoned-cart' ); ?> 
                                     <strong> 
                                         <?php $total_of_all_order = $wcal_recover_orders_list->total_order_amount; 
                                                
                                         echo $total_of_all_order; ?>
                                      </strong>
-                                     <?php _e( ' were abandoned. We were able to recover', 'woocommerce-ac' ); ?> 
+                                     <?php _e( ' were abandoned. We were able to recover', 'woocommerce-abandoned-cart' ); ?> 
                                      <strong>
                                         <?php 
                                         $recovered_item = $wcal_recover_orders_list->recovered_item;
                                         
                                         echo $recovered_item; ?>
                                      </strong>
-                                     <?php _e( ' of them, which led to an extra', 'woocommerce-ac' ); ?> 
+                                     <?php _e( ' of them, which led to an extra', 'woocommerce-abandoned-cart' ); ?> 
                                      <strong>
                                         <?php 
                                             $recovered_total = $wcal_recover_orders_list->total_recover_amount;
@@ -2542,15 +2547,15 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                         ?>
                         <p> </p>
                         <div id="ac_order_details" class="postbox" style="display:block">
-                            <h3> <p> <?php _e( "Abandoned Order #$ac_order_id Details", "woocommerce-ac" ); ?> </p> </h3>
+                            <h3> <p> <?php printf( __( 'Abandoned Order #%s Details', 'woocommerce-abandoned-cart' ), $ac_order_id); ?> </p> </h3>
                             <div class="inside">
                                 <table cellpadding="0" cellspacing="0" class="wp-list-table widefat fixed posts">
                                     <tr>
-                                        <th> <?php _e( 'Item', 'woocommerce-ac' ); ?> </th>
-                                        <th> <?php _e( 'Name', 'woocommerce-ac' ); ?> </th>
-                                        <th> <?php _e( 'Quantity', 'woocommerce-ac' ); ?> </th>
-                                        <th> <?php _e( 'Line Subtotal', 'woocommerce-ac' ); ?> </th>
-                                        <th> <?php _e( 'Line Total', 'woocommerce-ac' ); ?> </th>
+                                        <th> <?php _e( 'Item', 'woocommerce-abandoned-cart' ); ?> </th>
+                                        <th> <?php _e( 'Name', 'woocommerce-abandoned-cart' ); ?> </th>
+                                        <th> <?php _e( 'Quantity', 'woocommerce-abandoned-cart' ); ?> </th>
+                                        <th> <?php _e( 'Line Subtotal', 'woocommerce-abandoned-cart' ); ?> </th>
+                                        <th> <?php _e( 'Line Total', 'woocommerce-abandoned-cart' ); ?> </th>
                                     </tr>                                           
                                     <?php 
                                     $query = "SELECT * FROM `".$wpdb->prefix."ac_abandoned_cart_history_lite` WHERE id = %d ";
@@ -2791,15 +2796,15 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                             </div>  
                         </div>
                         <div id="ac_order_customer_details" class="postbox" style="display:block">
-                            <h3> <p> <?php _e( 'Customer Details' , 'woocommerce-ac' ); ?> </p> </h3>
+                            <h3> <p> <?php _e( 'Customer Details' , 'woocommerce-abandoned-cart' ); ?> </p> </h3>
                             <div class="inside" style="height: 300px;" >                                       
                                 <div id="order_data" class="panel">
                                     <div style="width:50%;float:left">
-                                        <h3> <p> <?php _e( 'Billing Details' , 'woocommerce-ac' ); ?> </p> </h3>
-                                        <p> <strong> <?php _e( 'Name:' , 'woocommerce-ac' ); ?> </strong>
+                                        <h3> <p> <?php _e( 'Billing Details' , 'woocommerce-abandoned-cart' ); ?> </p> </h3>
+                                        <p> <strong> <?php _e( 'Name:' , 'woocommerce-abandoned-cart' ); ?> </strong>
                                             <?php echo $user_first_name." ".$user_last_name;?>
                                         </p>                                    
-                                        <p> <strong> <?php _e( 'Address:' , 'woocommerce-ac' ); ?> </strong>
+                                        <p> <strong> <?php _e( 'Address:' , 'woocommerce-abandoned-cart' ); ?> </strong>
                                             <?php echo $user_billing_company."</br>".
                                                        $user_billing_address_1."</br>".
                                                        $user_billing_address_2."</br>".
@@ -2809,17 +2814,17 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                                        $user_billing_country."</br>";
                                                        ?> 
                                         </p>                                        
-                                        <p> <strong> <?php _e( 'Email:', 'woocommerce-ac' ); ?> </strong>
+                                        <p> <strong> <?php _e( 'Email:', 'woocommerce-abandoned-cart' ); ?> </strong>
                                             <?php $user_mail_to =  "mailto:".$user_email; ?>
                                             <a href=<?php echo $user_mail_to;?>><?php echo $user_email;?> </a>
                                         </p>                                            
-                                        <p> <strong> <?php _e( 'Phone:', 'woocommerce-ac' ); ?> </strong>
+                                        <p> <strong> <?php _e( 'Phone:', 'woocommerce-abandoned-cart' ); ?> </strong>
                                             <?php echo $user_billing_phone;?>
                                         </p>
                                     </div>                                                                                   
                                     <div style="width:50%;float:right">
-                                        <h3> <p> <?php _e( 'Shipping Details', 'woocommerce-ac' ); ?> </p> </h3>                                       
-                                        <p> <strong> <?php _e( 'Address:', 'woocommerce-ac' ); ?> </strong>
+                                        <h3> <p> <?php _e( 'Shipping Details', 'woocommerce-abandoned-cart' ); ?> </p> </h3>                                       
+                                        <p> <strong> <?php _e( 'Address:', 'woocommerce-abandoned-cart' ); ?> </strong>
                                             <?php 
                                             if ( $user_shipping_company     == '' &&
                                                  $user_shipping_address_1   == '' &&
@@ -2901,12 +2906,12 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                         print'<input type="hidden" name="ac_settings_frm" value="'.$button_mode.'">';?>
                         <div id="poststuff">
                             <div> <!-- <div class="postbox" > -->
-                                <h3 class="hndle"><?php _e( $display_message, 'woocommerce-ac' ); ?></h3>
+                                <h3 class="hndle"><?php _e( $display_message, 'woocommerce-abandoned-cart' ); ?></h3>
                                 <div>
                                   <table class="form-table" id="addedit_template">
                                     <tr>
                                         <th>
-                                            <label for="woocommerce_ac_template_name"><b><?php _e( 'Template Name:', 'woocommerce-ac');?></b></label>
+                                            <label for="woocommerce_ac_template_name"><b><?php _e( 'Template Name:', 'woocommerce-abandoned-cart');?></b></label>
                                         </th>
                                         <td>
                                             <?php
@@ -2915,13 +2920,13 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                                 $template_name = $results[0]->template_name;
                                             }                                           
                                             print'<input type="text" name="woocommerce_ac_template_name" id="woocommerce_ac_template_name" class="regular-text" value="'.$template_name.'">';?>
-                                            <img class="help_tip" width="16" height="16" data-tip='<?php _e('Enter a template name for reference', 'woocommerce-ac') ?>' src="<?php echo plugins_url(); ?>/woocommerce/assets/images/help.png" />
+                                            <img class="help_tip" width="16" height="16" data-tip='<?php _e('Enter a template name for reference', 'woocommerce-abandoned-cart') ?>' src="<?php echo plugins_url(); ?>/woocommerce/assets/images/help.png" />
                                         </td>
                                     </tr>
                                     
                                     <tr>
                                        <th>
-                                            <label for="woocommerce_ac_email_subject"><b><?php _e( 'Subject:', 'woocommerce-ac' ); ?></b></label>
+                                            <label for="woocommerce_ac_email_subject"><b><?php _e( 'Subject:', 'woocommerce-abandoned-cart' ); ?></b></label>
                                         </th>
                                         <td>
                                             <?php
@@ -2930,13 +2935,13 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                                 $subject_edit= stripslashes ( $results[0]->subject );
                                             }                                           
                                             print'<input type="text" name="woocommerce_ac_email_subject" id="woocommerce_ac_email_subject" class="regular-text" value="'.$subject_edit.'">';?>
-                                            <img class="help_tip" width="16" height="16" data-tip='<?php _e('Enter the subject that should appear in the email sent', 'woocommerce-ac') ?>' src="<?php echo plugins_url(); ?>/woocommerce/assets/images/help.png" />
+                                            <img class="help_tip" width="16" height="16" data-tip='<?php _e('Enter the subject that should appear in the email sent', 'woocommerce-abandoned-cart') ?>' src="<?php echo plugins_url(); ?>/woocommerce/assets/images/help.png" />
                                         </td>
                                     </tr>
 
                                     <tr>
                                         <th>
-                                            <label for="woocommerce_ac_email_body"><b><?php _e( 'Email Body:', 'woocommerce-ac' ); ?></b></label>
+                                            <label for="woocommerce_ac_email_body"><b><?php _e( 'Email Body:', 'woocommerce-abandoned-cart' ); ?></b></label>
                                         </th>
                                         <td>            
                                             <?php
@@ -2962,14 +2967,14 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                             ?>
                                             <?php echo stripslashes( get_option( 'woocommerce_ac_email_body' ) ); ?>
                                             <span class="description"><?php
-                                                echo __( 'Message to be sent in the reminder email.', 'woocommerce-ac' );
+                                                 _e( 'Message to be sent in the reminder email.', 'woocommerce-abandoned-cart' );
                                             ?></span>
                                         </td>
                                     </tr>
                                     
                                      <tr>
                                         <th>
-                                            <label for="is_wc_template"><b><?php _e( 'Use WooCommerce Template Style:', 'woocommerce-ac' ); ?></b></label>
+                                            <label for="is_wc_template"><b><?php _e( 'Use WooCommerce Template Style:', 'woocommerce-abandoned-cart' ); ?></b></label>
                                         </th>
                                         <td>
                                             <?php
@@ -2984,14 +2989,14 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                                 }
                                             }
                                             print'<input type="checkbox" name="is_wc_template" id="is_wc_template" ' . $is_wc_template . '>  </input>'; ?>
-                                            <img class="help_tip" width="16" height="16" data-tip='<?php _e( 'Use WooCommerce default style template for abandoned cart reminder emails.', 'woocommerce' ) ?>' src="<?php echo plugins_url(); ?>/woocommerce/assets/images/help.png" /> <a target = '_blank' href= <?php  echo wp_nonce_url( admin_url( '?wcal_preview_woocommerce_mail=true' ), 'woocommerce-ac' ) ; ?> > 
-                                            Click here to preview </a>how the email template will look with WooCommerce Template Style enabled. Alternatively, if this is unchecked, the template will appear as <a target = '_blank' href=<?php  echo wp_nonce_url( admin_url( '?wcal_preview_mail=true' ), 'woocommerce-ac' ) ; ?>>shown here</a>. <br> <strong>Note: </strong>When this setting is enabled, then "Send From This Name:" & "Send From This Email Address:" will be overwritten with WooCommerce -> Settings -> Email -> Email Sender Options.   
+                                            <img class="help_tip" width="16" height="16" data-tip='<?php _e( 'Use WooCommerce default style template for abandoned cart reminder emails.', 'woocommerce' ) ?>' src="<?php echo plugins_url(); ?>/woocommerce/assets/images/help.png" /> <a target = '_blank' href= <?php  echo wp_nonce_url( admin_url( '?wcal_preview_woocommerce_mail=true' ), 'woocommerce-abandoned-cart' ) ; ?> > 
+                                            Click here to preview </a>how the email template will look with WooCommerce Template Style enabled. Alternatively, if this is unchecked, the template will appear as <a target = '_blank' href=<?php  echo wp_nonce_url( admin_url( '?wcal_preview_mail=true' ), 'woocommerce-abandoned-cart' ) ; ?>>shown here</a>. <br> <strong>Note: </strong>When this setting is enabled, then "Send From This Name:" & "Send From This Email Address:" will be overwritten with WooCommerce -> Settings -> Email -> Email Sender Options.   
                                         </td>
                                      </tr>
                                      
                                      <tr>
                                         <th>
-                                            <label for="wcal_wc_email_header"><b><?php _e( 'Email Template Header Text: ', 'woocommerce-ac' ); ?></b></label>
+                                            <label for="wcal_wc_email_header"><b><?php _e( 'Email Template Header Text: ', 'woocommerce-abandoned-cart' ); ?></b></label>
                                         </th>
                                         <td>
 
@@ -3005,13 +3010,13 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                             $wcal_wc_email_header = "Abandoned cart reminder";
                                         }
                                         print'<input type="text" name="wcal_wc_email_header" id="wcal_wc_email_header" class="regular-text" value="' . $wcal_wc_email_header . '">'; ?>
-                                        <img class="help_tip" width="16" height="16" data-tip='<?php _e( 'Enter the header which will appear in the abandoned WooCommerce email sent. This is only applicable when only used when "Use WooCommerce Template Style:" is checked.', 'woocommerce-ac' ) ?>' src="<?php echo plugins_url(); ?>/woocommerce/assets/images/help.png" />
+                                        <img class="help_tip" width="16" height="16" data-tip='<?php _e( 'Enter the header which will appear in the abandoned WooCommerce email sent. This is only applicable when only used when "Use WooCommerce Template Style:" is checked.', 'woocommerce-abandoned-cart' ) ?>' src="<?php echo plugins_url(); ?>/woocommerce/assets/images/help.png" />
                                         </td>
                                     </tr> 
                                      
                                     <tr>
                                         <th>
-                                            <label for="woocommerce_ac_email_frequency"><b><?php _e( 'Send this email:', 'woocommerce-ac' ); ?></b></label>
+                                            <label for="woocommerce_ac_email_frequency"><b><?php _e( 'Send this email:', 'woocommerce-abandoned-cart' ); ?></b></label>
                                         </th>
                                         <td>
                                             <select name="email_frequency" id="email_frequency">
@@ -3052,19 +3057,19 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                                 ?>
                                             </select>           
                                             <span class="description">
-                                              <?php echo __( 'after cart is abandoned.', 'woocommerce-ac' ); ?>
+                                              <?php _e( 'after cart is abandoned.', 'woocommerce-abandoned-cart' ); ?>
                                             </span>
                                         </td>
                                     </tr>
                                     
                                     <tr>
                                         <th>
-                                            <label for="woocommerce_ac_email_preview"><b><?php _e( 'Send a test email to:', 'woocommerce-ac' ); ?></b></label>
+                                            <label for="woocommerce_ac_email_preview"><b><?php _e( 'Send a test email to:', 'woocommerce-abandoned-cart' ); ?></b></label>
                                         </th>
                                         <td> 
                                             <input type="text" id="send_test_email" name="send_test_email" class="regular-text" >
                                             <input type="button" value="Send a test email" id="preview_email" onclick="javascript:void(0);">
-                                            <img class="help_tip" width="16" height="16" data-tip='<?php _e('Enter the email id to which the test email needs to be sent.', 'woocommerce-ac') ?>' src="<?php echo plugins_url(); ?>/woocommerce/assets/images/help.png" />
+                                            <img class="help_tip" width="16" height="16" data-tip='<?php _e('Enter the email id to which the test email needs to be sent.', 'woocommerce-abandoned-cart') ?>' src="<?php echo plugins_url(); ?>/woocommerce/assets/images/help.png" />
                                             <div id="preview_email_sent_msg" style="display:none;"></div>
                                         </td>
                                     </tr>                                               
@@ -3079,7 +3084,7 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                             {
                                 $button_value = "Update Changes";
                             }?>
-                        <input type="submit" name="Submit" class="button-primary" value="<?php esc_attr_e( $button_value, 'woocommerce-ac' ); ?>"  />
+                        <input type="submit" name="Submit" class="button-primary" value="<?php esc_attr_e( $button_value, 'woocommerce-abandoned-cart' ); ?>"  />
                       </p>
                     </form>
               </div>
@@ -3091,7 +3096,7 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
 
             if ( isset( $_GET[ 'page' ] ) && $_GET[ 'page' ] === 'woocommerce_ac_page' ) {
                 $footer_text = sprintf( __( 'If you love <strong>Abandoned Cart Lite for WooCommerce</strong>, then please leave us a <a href="https://wordpress.org/support/plugin/woocommerce-abandoned-cart/reviews/?rate=5#new-post" target="_blank" class="ac-rating-link" data-rated="Thanks :)">★★★★★</a>
-                            rating. Thank you in advance. :)', 'woocommerce-ac' ) );
+                            rating. Thank you in advance. :)', 'woocommerce-abandoned-cart' ) );
                 wc_enqueue_js( "
                         jQuery( 'a.ac-rating-link' ).click( function() {
                             jQuery( this ).parent().text( jQuery( this ).data( 'rated' ) );
@@ -3230,24 +3235,24 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                     $headers          .= "Content-Type: text/plain" . "\r\n";
                     $headers          .= "Reply-To:  " . $reply_name_preview . " " . "\r\n";
                     $var               =  '<table width = 100%>
-                                            <tr> <td colspan="5"> <h3>'.__( "Your Shopping Cart", "woocommerce-ac" ).'</h3> </td></tr>
+                                            <tr> <td colspan="5"> <h3>'.__( 'Your Shopping Cart', 'woocommerce-abandoned-cart' ).'</h3> </td></tr>
                                             <tr align="center">
-                                               <th>'.__( "Item", "woocommerce-ac" ).'</th>
-                                               <th>'.__( "Name", "woocommerce-ac" ).'</th>
-                                               <th>'.__( "Quantity", "woocommerce-ac" ).'</th>
-                                               <th>'.__( "Price", "woocommerce-ac" ).'</th>
-                                               <th>'.__( "Line Subtotal", "woocommerce-ac" ).'</th>
+                                               <th>'.__( 'Item', 'woocommerce-abandoned-cart' ).'</th>
+                                               <th>'.__( 'Name', 'woocommerce-abandoned-cart' ).'</th>
+                                               <th>'.__( 'Quantity', 'woocommerce-abandoned-cart' ).'</th>
+                                               <th>'.__( 'Price', 'woocommerce-abandoned-cart' ).'</th>
+                                               <th>'.__( 'Line Subtotal', 'woocommerce-abandoned-cart' ).'</th>
                                             </tr>
                                             <tr align="center">
                                                <td><img class="demo_img" width="42" height="42" src="'.plugins_url().'/woocommerce-abandoned-cart/assets/images/shoes.jpg"/></td>
-                                               <td>'.__( "Men\'\s Formal Shoes", "woocommerce-ac" ).'</td>
+                                               <td>'.__( "Men\'\s Formal Shoes", 'woocommerce-abandoned-cart' ).'</td>
                                                <td>1</td>
                                                <td>' . $wcal_price . '</td>
                                                <td>' . $wcal_price . '</td>
                                             </tr>
                                             <tr align="center">
                                                <td><img class="demo_img" width="42" height="42" src="'.plugins_url().'/woocommerce-abandoned-cart/assets/images/handbag.jpg"/></td>
-                                               <td>'.__( "Woman\'\s Hand Bags", "woocommerce-ac" ).'</td>
+                                               <td>'.__( "Woman\'\s Hand Bags", 'woocommerce-abandoned-cart' ).'</td>
                                                <td>1</td>
                                                <td>' . $wcal_price . '</td>
                                                <td>' . $wcal_price . '</td>
@@ -3256,7 +3261,7 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                                <td></td>
                                                <td></td>
                                                <td></td>
-                                               <td>'.__( "Cart Total:", "woocommerce-ac" ).'</td>
+                                               <td>'.__( "Cart Total:", 'woocommerce-abandoned-cart' ).'</td>
                                                <td>' . $wcal_total_price . '</td>
                                             </tr>
                                         </table>';
@@ -3264,25 +3269,25 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                     $headers           = "From: " . $from_email_name . " <" . $from_email_preview . ">" . "\r\n";
                     $headers          .= "Content-Type: text/html" . "\r\n";
                     $headers          .= "Reply-To:  " . $reply_name_preview . " " . "\r\n";
-                    $var               = '<h3>'.__( "Your Shopping Cart", "woocommerce-ac" ).'</h3>
+                    $var               = '<h3>'.__( "Your Shopping Cart", 'woocommerce-abandoned-cart' ).'</h3>
                                         <table border="0" cellpadding="10" cellspacing="0" class="templateDataTable">
                                             <tr align="center">
-                                               <th>'.__( "Item", "woocommerce-ac" ).'</th>
-                                               <th>'.__( "Name", "woocommerce-ac" ).'</th>
-                                               <th>'.__( "Quantity", "woocommerce-ac" ).'</th>
-                                               <th>'.__( "Price", "woocommerce-ac" ).'</th>
-                                               <th>'.__( "Line Subtotal", "woocommerce-ac" ).'</th>
+                                               <th>'.__( "Item", 'woocommerce-abandoned-cart' ).'</th>
+                                               <th>'.__( "Name", 'woocommerce-abandoned-cart' ).'</th>
+                                               <th>'.__( "Quantity", 'woocommerce-abandoned-cart' ).'</th>
+                                               <th>'.__( "Price", 'woocommerce-abandoned-cart' ).'</th>
+                                               <th>'.__( "Line Subtotal", 'woocommerce-abandoned-cart' ).'</th>
                                             </tr>
                                             <tr align="center">
                                                <td><img class="demo_img" width="42" height="42" src="'.plugins_url().'/woocommerce-abandoned-cart/assets/images/shoes.jpg"/></td>
-                                               <td>'.__( "Men\'\s Formal Shoes", "woocommerce-ac" ).'</td>
+                                               <td>'.__( "Men\'\s Formal Shoes", 'woocommerce-abandoned-cart' ).'</td>
                                                <td>1</td>
                                                <td>' . $wcal_price . '</td>
                                                <td>' . $wcal_price . '</td>
                                             </tr>
                                             <tr align="center">
                                                <td><img class="demo_img" width="42" height="42" src="'.plugins_url().'/woocommerce-abandoned-cart/assets/images/handbag.jpg"/></td>
-                                               <td>'.__( "Woman\'\s Hand Bags", "woocommerce-ac" ).'</td>
+                                               <td>'.__( "Woman\'\s Hand Bags", 'woocommerce-abandoned-cart' ).'</td>
                                                <td>1</td>
                                                <td>' . $wcal_price . '</td>
                                                <td>' . $wcal_price . '</td>
@@ -3291,7 +3296,7 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                                <td></td>
                                                <td></td>
                                                <td></td>
-                                               <td>'.__( "Cart Total:", "woocommerce-ac" ).'</td>
+                                               <td>'.__( "Cart Total:", 'woocommerce-abandoned-cart' ).'</td>
                                                <td>' . $wcal_total_price . '</td>
                                             </tr>
                                          </table>';


### PR DESCRIPTION
Our plugin were not prepared for localization on the
translate.wordpress.org page.

As we were using the domain name as "woocommerce-ac". But as per
WordPress translation rules, if the plugin is hosted on wordpress.org
then domain name should be slug of our plugin URL
(wordpress.org/plugins/<slug>) which is "woocommerce-abandoned-cart".

So, I have changed our textdomain from "woocommerce-ac" to
"woocommerce-abandoned-cart".

Now, our plugin should be translated on translate.wordpress.org page.