### PR TITLE
Version 4.7

### DIFF
--- a/woocommerce-abandoned-cart/woocommerce-ac.php
+++ b/woocommerce-abandoned-cart/woocommerce-ac.php
@@ -3,7 +3,7 @@
 * Plugin Name: Abandoned Cart Lite for WooCommerce
 * Plugin URI: http://www.tychesoftwares.com/store/premium-plugins/woocommerce-abandoned-cart-pro
 * Description: This plugin captures abandoned carts by logged-in users & emails them about it. <strong><a href="http://www.tychesoftwares.com/store/premium-plugins/woocommerce-abandoned-cart-pro">Click here to get the PRO Version.</a></strong>
-* Version: 4.6
+* Version: 4.7
 * Author: Tyche Softwares
 * Author URI: http://www.tychesoftwares.com/
 * Text Domain: woocommerce-abandoned-cart
@@ -632,7 +632,7 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             /*
             * Due to the introduction of language packs through translate.wordpress.org, loading our textdomain is complex.
             *
-            * In v4.8, our textdomain changed from "woocommerce-ac" to "woocommerce-abandoned-cart".
+            * In v4.7, our textdomain changed from "woocommerce-ac" to "woocommerce-abandoned-cart".
             */
             $domain = 'woocommerce-abandoned-cart';
             $locale = apply_filters( 'plugin_locale', get_locale(), $domain );


### PR DESCRIPTION
Changelog for version 4.7 Abandoned Cart LITE for WooCommerce

This
version has 2 bug fixes.

1. Due to the introduction of language packs
through translate.wordpress.org, our plugin was not prepared for
localization. So, we changed textdomain from "woocommerce-ac" to
"woocommerce-abandoned-cart".
2. Warning error messages had been
displayed on Abandoned Orders tab and Recovered Orders tab with PHP 7.2.
This issue has been fixed.