### PR TITLE
CSS Updates for abandoned order views

### DIFF
--- a/woocommerce-abandoned-cart/assets/css/view.abandoned.orders.style.css
+++ b/woocommerce-abandoned-cart/assets/css/view.abandoned.orders.style.css
@@ -58,3 +58,11 @@ table.wp-list-table td img {
     max-width: 100%;
     height: auto;
 }
+
+/**
+ * Add left/right margin to h3 titles.
+ */
+h3.details-title {
+    margin-left: 12px;
+    margin-right: 12px;
+}

--- a/woocommerce-abandoned-cart/assets/css/view.abandoned.orders.style.css
+++ b/woocommerce-abandoned-cart/assets/css/view.abandoned.orders.style.css
@@ -1,6 +1,6 @@
 /**
  * Decrease the width of the Id column.
- * 
+ *
  */
 table.wp-list-table .column-id {
 	width:5%;
@@ -8,12 +8,12 @@ table.wp-list-table .column-id {
 
 /**
  * Decrease the width of the email column.
- */ 
+ */
 table.wp-list-table .column-email {
 	width:15%;
 }
 
-/** 
+/**
  * Decrease the width of the abandoned order date column.
  */
 table.wp-list-table .column-date {
@@ -27,18 +27,18 @@ table.wp-list-table .column-order_total {
 	width:20%;
 }
 
-/** 
+/**
  * This is for the new cart and checkout button in tinymce.
  */
 #woocommerce_ac_email_body_abandoncart_email_variables_css{
-	
+
 	width : 60px !important;
 }
 span.mce_abandoncart_email_variables_css {
 	width : 60px !important;
 }
 
-/** 
+/**
  * Decrease the width of the sr column in templates tab.
  */
 table.wp-list-table .column-sr {
@@ -49,4 +49,12 @@ i.mce-i-abandoncart_email_variables {
     background-image: url(../images/ac_editor_icon.png) ;
     width: 30px;
     height: 30px;
+}
+
+/**
+ * Resize product image to fit within td.
+ */
+table.wp-list-table td img {
+    max-width: 100%;
+    height: auto;
 }

--- a/woocommerce-abandoned-cart/woocommerce-ac.php
+++ b/woocommerce-abandoned-cart/woocommerce-ac.php
@@ -2763,7 +2763,7 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                         ?>
                         <p> </p>
                         <div id="ac_order_details" class="postbox" style="display:block">
-                            <h3> <p> <?php printf( __( 'Abandoned Order #%s Details', 'woocommerce-abandoned-cart' ), $ac_order_id); ?> </p> </h3>
+                            <h3 class="details-title"> <p> <?php printf( __( 'Abandoned Order #%s Details', 'woocommerce-abandoned-cart' ), $ac_order_id); ?> </p> </h3>
                             <div class="inside">
                                 <table cellpadding="0" cellspacing="0" class="wp-list-table widefat fixed posts">
                                     <tr>
@@ -3012,8 +3012,8 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                             </div>  
                         </div>
                         <div id="ac_order_customer_details" class="postbox" style="display:block">
-                            <h3> <p> <?php _e( 'Customer Details' , 'woocommerce-abandoned-cart' ); ?> </p> </h3>
-                            <div class="inside" style="height: 300px;" >                                       
+                            <h3 class="details-title"> <p> <?php _e( 'Customer Details' , 'woocommerce-abandoned-cart' ); ?> </p> </h3>
+                            <div class="inside" style="height: 300px;" >
                                 <div id="order_data" class="panel">
                                     <div style="width:50%;float:left">
                                         <h3> <p> <?php _e( 'Billing Details' , 'woocommerce-abandoned-cart' ); ?> </p> </h3>


### PR DESCRIPTION
![screenshot-2018-5-15 abandoned carts woocommerce wordpress 1](https://user-images.githubusercontent.com/9917957/40069213-b0c05bb8-5838-11e8-9bb8-65b5bcbb343f.png)

### Updates

- The image gets resized with a max-width so it doesn't float outside of the `<td>` (ref: #290)
- The "Abandoned order details" and "Customer details" titles get margin to align with the content below