### PR TITLE
We do not track any data when selected No in tracking

### DIFF
--- a/woocommerce-abandoned-cart/includes/component/tracking data/class-ts-tracker.php
+++ b/woocommerce-abandoned-cart/includes/component/tracking data/class-ts-tracker.php
@@ -78,7 +78,7 @@ class TS_Tracker {
 			$params   = array();
 			$params[ 'tracking_usage' ] = 'no';
 			$params[ 'url' ]            = home_url();
-			$params[ 'email' ]          = apply_filters( 'ts_tracker_admin_email', get_option( 'admin_email' ) );
+			$params[ 'email' ]          = '';
 			
 			$params 					= apply_filters( 'ts_tracker_opt_out_data', $params );
 		} else {

--- a/woocommerce-abandoned-cart/includes/wcal-common.php
+++ b/woocommerce-abandoned-cart/includes/wcal-common.php
@@ -442,7 +442,7 @@ class wcal_common {
 			// Get all plugin options info
 			$plugin_data[ 'settings' ]          				= self::wcal_ts_get_all_plugin_options_values();
 			$plugin_data[ 'plugin_version' ]    				= self::wcal_get_version();
-			$plugin_data[ 'wcal_allow_tracking' ]      			= get_option ('wcal_allow_tracking');
+			$plugin_data[ 'tracking_usage' ]      			    = get_option ('wcal_allow_tracking');
 			
 			$data [ 'plugin_data' ] = $plugin_data;
 		}
@@ -459,9 +459,6 @@ class wcal_common {
 
 		$plugin_data[ 'ts_meta_data_table_name']   = 'ts_wcal_tracking_meta_data';
 		$plugin_data[ 'ts_plugin_name' ]		   = 'Abandoned Cart Lite for WooCommerce';
-		$plugin_data[ 'abandoned_orders_amount' ]  = self::wcal_ts_get_abandoned_order_total_amount();
-		// Store recovered count info
-		$plugin_data[ 'recovered_orders_amount' ]  = self::wcal_ts_get_recovered_order_total_amount();
 		
 		$params[ 'plugin_data' ]  				   = $plugin_data;
 


### PR DESCRIPTION
When select No for the tracking we send the admin email along with some abandoned cart data.

Now, we do capture admin email and do not send any cart related data