### PR TITLE
Comply with GDPR

### DIFF
--- a/woocommerce-abandoned-cart/includes/admin/wcal_privacy_erase.php
+++ b/woocommerce-abandoned-cart/includes/admin/wcal_privacy_erase.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * Export Abandoned Carts data in 
+ * Dashboard->Tools->Erase Personal Data
+ * 
+ * @since 4.9
+ */
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+if ( !class_exists('Wcal_Personal_Data_Eraser' ) ) {
+
+    /**
+     * Export Abandoned Carts data in
+     * Dashboard->Tools->Erase Personal Data
+     */
+    class Wcal_Personal_Data_Eraser {
+    
+        /**
+         * Construct
+         * @since 4.9
+         */
+        public function __construct() {
+            // Hook into the WP erase process
+            add_filter( 'wp_privacy_personal_data_erasers', array( &$this, 'wcal_eraser_array' ), 6 );
+        }
+    
+        /**
+         * Add our eraser and it's callback function
+         *
+         * @param array $erasers - Any erasers that need to be added by 3rd party plugins
+         * @param array $erasers - Erasers list containing our plugin details
+         *
+         * @since 4.9
+         */
+        public static function wcal_eraser_array( $erasers = array() ) {
+            
+            $eraser_list = array();
+            // Add our eraser and it's callback function
+            $eraser_list[ 'wcal_carts' ] = array( 
+                'eraser_friendly_name' => __( 'Abandoned & Recovered Carts', 'woocommerce-abandoned-cart' ),
+                'callback'               => array( 'Wcal_Personal_Data_Eraser', 'wcal_data_eraser' )
+            );
+             
+            $erasers = array_merge( $erasers, $eraser_list );
+
+            return $erasers;
+            
+        }
+        
+        /**
+         * Erases personal data for abandoned carts.
+         *
+         * @param string $email_address - EMail Address for which personal data is being exported
+         * @param integer $page - The Eraser page number
+         * @return array $reponse - Whether the process was successful or no
+         *
+         * @hook wp_privacy_personal_data_erasers
+         * @global $wpdb
+         * @since  4.9
+         */
+        static function wcal_data_eraser( $email_address, $page ) {
+            global $wpdb;
+            
+            $page            = (int) $page;
+            $user            = get_user_by( 'email', $email_address ); // Check if user has an ID in the DB to load stored personal data.
+            $erasure_enabled = wc_string_to_bool( get_option( 'woocommerce_erasure_request_removes_order_data', 'no' ) );
+            $response        = array(
+                'items_removed'  => false,
+                'items_retained' => false,
+                'messages'       => array(),
+                'done'           => true,
+            );
+        
+            $user_id = $user ? (int) $user->ID : 0;
+            
+            if( $user_id > 0 ) { // registered user
+                $cart_query = "SELECT id FROM `" . $wpdb->prefix . 'ac_abandoned_cart_history_lite' . "`
+                                WHERE user_id = %d AND
+                                user_type = 'REGISTERED'";
+                
+                $cart_ids = $wpdb->get_results( $wpdb->prepare( $cart_query, $user_id ) );
+            } else { // guest carts
+                $guest_query = "SELECT id FROM `" . $wpdb->prefix . 'ac_guest_abandoned_cart_history_lite' . "`
+                                WHERE email_id = %s";
+                
+                $guest_user_ids = $wpdb->get_results( $wpdb->prepare( $guest_query, $email_address ) );
+                
+                if( count( $guest_user_ids ) == 0 ) 
+                    return;
+                
+                $cart_ids = array();
+                
+                foreach( $guest_user_ids as $ids ) {
+                    // get the cart data
+                    $cart_query = "SELECT id FROM `" . $wpdb->prefix . 'ac_abandoned_cart_history_lite' . "`
+                                    WHERE user_id = %d AND
+                                    user_type = 'GUEST'";
+                    
+                    $cart_data = $wpdb->get_results( $wpdb->prepare( $cart_query, $ids->id ) );
+            
+                    $cart_ids = array_merge( $cart_ids, $cart_data );
+                }
+            }
+            
+            if ( 0 < count( $cart_ids ) ) {
+                
+                $cart_chunks = array_chunk( $cart_ids, 10, true );
+                
+                $cart_export = isset( $cart_chunks[ $page - 1 ] ) ? $cart_chunks[ $page - 1 ] : array();
+                if( count( $cart_export ) > 0 ) {
+                    foreach ( $cart_export as $abandoned_ids ) {
+                        $cart_id = $abandoned_ids->id;
+                        
+                        if ( apply_filters( 'wcal_privacy_erase_cart_personal_data', $erasure_enabled, $cart_id ) ) {
+                            self::remove_cart_personal_data( $cart_id );
+                        
+                            /* Translators: %s Abandoned Cart ID. */
+                            $response['messages'][]    = sprintf( __( 'Removed personal data from cart %s.', 'woocommerce-abandoned-cart' ), $cart_id );
+                            $response['items_removed'] = true;
+                        } else {
+                            /* Translators: %s Abandoned Cart ID. */
+                            $response['messages'][]     = sprintf( __( 'Personal data within cart %s has been retained.', 'woocommerce-abandoned-cart' ), $cart_id );
+                            $response['items_retained'] = true;
+                        }
+                        
+                    }
+                    $response['done'] = $page > count( $cart_chunks );
+                } else {
+                    $response['done'] = true;
+                }
+            } else {
+                $response['done'] = true;
+            }
+            return $response;    
+        }
+        
+        /**
+         * Erases the personal data for each abandoned cart
+         *
+         * @param integer $abandoned_id - Abandoned Cart ID
+         * @global $wpdb
+         * @since  4.9
+         */
+        static function remove_cart_personal_data( $abandoned_id ) {
+            global $wpdb;
+            
+            $anonymized_cart = array();
+            $anonymized_guest = array();
+            
+            do_action( 'wcal_privacy_before_remove_cart_personal_data', $abandoned_id );
+
+            // list the props we'll be anonymizing for cart history table
+            $props_to_remove_cart = apply_filters( 'wcal_privacy_remove_cart_personal_data_props', array(
+                'session_id'          => 'numeric_id',
+                ), 
+                $abandoned_id 
+            );
+            
+            // list the props we'll be anonymizing for guest cart history table
+            $props_to_remove_guest = apply_filters( 'wcal_privacy_remove_cart_personal_data_props_guest', array( 
+                'billing_first_name'  => 'text',
+                'billing_last_name'   => 'text',
+                'phone'               => 'phone',
+                'email_id'            => 'email' ), $abandoned_id );
+                
+
+            if ( ! empty( $props_to_remove_cart ) && is_array( $props_to_remove_cart ) ) {
+                
+                // get the data from cart history 
+                $cart_query = "SELECT session_id, user_type, user_id FROM `" . $wpdb->prefix . 'ac_abandoned_cart_history_lite' . "`
+                                WHERE id = %d";
+                $cart_details = $wpdb->get_results( $wpdb->prepare( $cart_query, $abandoned_id ) );
+                
+                if( count( $cart_details ) > 0 ) {
+                    $cart_details = $cart_details[0];
+                } else {
+                    return;
+                }
+
+                $user_id = $cart_details->user_id;
+                $user_type = $cart_details->user_type;
+                
+                foreach ( $props_to_remove_cart as $prop => $data_type ) {
+                    
+                    $value = $cart_details->$prop;
+                    
+                    if ( empty( $value ) || empty( $data_type ) ) {
+                        continue;
+                    }
+                    
+                    if ( function_exists( 'wp_privacy_anonymize_data' ) ) {
+                        $anon_value = wp_privacy_anonymize_data( $data_type, $value );
+                    } else {
+                        $anon_value = '';
+                    }
+
+                    $anonymized_cart[ $prop ] = apply_filters( 'wcal_privacy_remove_cart_personal_data_prop_value', $anon_value, $prop, $value, $data_type, $abandoned_id );
+                }
+                $anonymized_cart[ 'user_type' ] = __( 'ANONYMIZED', 'woocommerce-abandoned-cart' );
+                // update the DB
+                $wpdb->update( $wpdb->prefix . 'ac_abandoned_cart_history_lite', $anonymized_cart, array( 'id' => $abandoned_id ) );
+            }
+            
+            // check whether it's a guest user
+            if( $user_type == 'GUEST' && ! empty( $props_to_remove_guest ) && is_array( $props_to_remove_guest ) ) {
+
+                // get the data from guest cart history
+                $guest_query = "SELECT billing_first_name, billing_last_name, phone, email_id FROM `" . $wpdb->prefix . 'ac_guest_abandoned_cart_history_lite' . "`
+                                WHERE id = %d";
+                $guest_details = $wpdb->get_results( $wpdb->prepare( $guest_query, $user_id ) );
+                
+                if( count( $guest_details ) > 0 ) {
+                    $guest_details = $guest_details[0];
+                } else {
+                    return;
+                }
+                
+                foreach ( $props_to_remove_guest as $prop => $data_type ) {
+                    $value = $guest_details->$prop;
+                
+                    if ( empty( $value ) || empty( $data_type ) ) {
+                        continue;
+                    }
+                
+                    if ( function_exists( 'wp_privacy_anonymize_data' ) ) {
+                        $anon_value = wp_privacy_anonymize_data( $data_type, $value );
+                    } else {
+                        $anon_value = '';
+                    }
+                
+                    $anonymized_guest[ $prop ] = apply_filters( 'wcal_privacy_remove_cart_personal_data_prop_value_guest', $anon_value, $prop, $value, $data_type, $abandoned_id );
+                }                
+                // update the DB
+                $wpdb->update( $wpdb->prefix . 'ac_guest_abandoned_cart_history_lite', $anonymized_guest, array( 'id' => $user_id ) );
+                
+            }
+                       
+        }
+        
+    } // end of class
+    $Wcal_Personal_Data_Eraser = new Wcal_Personal_Data_Eraser();
+} // end if
+?>

--- a/woocommerce-abandoned-cart/includes/admin/wcal_privacy_export.php
+++ b/woocommerce-abandoned-cart/includes/admin/wcal_privacy_export.php
@@ -1,0 +1,323 @@
+<?php
+/**
+ * Export Abandoned Carts data in 
+ * Dashboard->Tools->Export Personal Data
+ * 
+ * @since 4.9
+ */
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+if ( !class_exists('Wcal_Personal_Data_Export' ) ) {
+
+    /**
+     * Export Abandoned Carts data in
+     * Dashboard->Tools->Export Personal Data
+     */
+    class Wcal_Personal_Data_Export {
+    
+        /**
+         * Construct
+         * @since 7.8
+         */ 
+        public function __construct() {
+            // Hook into the WP export process
+            add_filter( 'wp_privacy_personal_data_exporters', array( &$this, 'wcal_exporter_array' ), 6 );
+        }
+    
+        /**
+         * Add our export and it's callback function
+         * 
+         * @param array $exporters - Any exportes that need to be added by 3rd party plugins
+         * @param array $exporters - Exportes list containing our plugin details
+         * 
+         * @since 4.9
+         */ 
+        public static function wcal_exporter_array( $exporters = array() ) {
+            
+            $exporter_list = array();
+            // Add our export and it's callback function
+            $exporter_list[ 'wcal_carts' ] = array( 
+                'exporter_friendly_name' => __( 'Abandoned & Recovered Carts', 'woocommerce-abandoned-cart' ),
+                'callback'               => array( 'Wcal_Personal_Data_Export', 'wcal_data_exporter' )
+            );
+             
+            $exporters = array_merge( $exporters, $exporter_list );
+
+            return $exporters;
+            
+        }
+        
+        /**
+         * Returns data to be displayed for exporting the 
+         * cart details
+         * 
+         * @param string $email_address - EMail Address for which personal data is being exported
+         * @param integer $page - The Export page number
+         * @return array $data_to_export - Data to be exported
+         * 
+         * @hook wp_privacy_personal_data_exporters
+         * @global $wpdb
+         * @since  4.9
+         */
+        static function wcal_data_exporter( $email_address, $page ) {
+            
+            global $wpdb;
+            
+            $done           = false;
+            $page           = (int) $page;
+            $user           = get_user_by( 'email', $email_address ); // Check if user has an ID in the DB to load stored personal data.
+            $data_to_export = array();
+            $blank_cart_info        = '{"cart":[]}';
+            $blank_cart_info_guest  = '[]';
+            $blank_cart             = '""';   
+            
+            $user_id = $user ? (int) $user->ID : 0;
+            
+            if( $user_id > 0 ) { // registered user
+                
+                $cart_query = "SELECT id FROM `" . $wpdb->prefix . 'ac_abandoned_cart_history_lite' . "`
+                                WHERE user_id = %d AND
+                                user_type = 'REGISTERED' AND abandoned_cart_info NOT LIKE '%$blank_cart_info%' AND abandoned_cart_info NOT LIKE '$blank_cart'";
+                
+                $cart_ids = $wpdb->get_results( $wpdb->prepare( $cart_query, $user_id ) );
+            } else { // guest carts
+                $guest_query = "SELECT id FROM `" . $wpdb->prefix . 'ac_guest_abandoned_cart_history_lite' . "`
+                                WHERE email_id = %s";
+                
+                $guest_user_ids = $wpdb->get_results( $wpdb->prepare( $guest_query, $email_address ) );
+                
+                if( count( $guest_user_ids ) == 0 ) 
+                    return;
+                
+                $cart_ids = array();
+                
+                foreach( $guest_user_ids as $ids ) {
+                    // get the cart data
+                    $cart_query = "SELECT id, abandoned_cart_info AS cart_info FROM `" . $wpdb->prefix . 'ac_abandoned_cart_history_lite' . "`
+                                    WHERE user_id = %d AND
+                                    user_type = 'GUEST'";
+                    
+                    $cart_data = $wpdb->get_results( $wpdb->prepare( $cart_query, $ids->id ) );
+                    
+                    $cart_ids = array_merge( $cart_ids, $cart_data );
+                }
+            }
+            
+            if ( 0 < count( $cart_ids ) ) {
+                
+                $cart_chunks = array_chunk( $cart_ids, 10, true );
+                
+                $cart_export = isset( $cart_chunks[ $page - 1 ] ) ? $cart_chunks[ $page - 1 ] : array();
+                if( count( $cart_export ) > 0 ) {
+                    
+                    foreach ( $cart_export as $abandoned_ids ) {
+                    
+                        $cart_id = $abandoned_ids->id;
+                        if( count( $abandoned_ids->cart_info ) > 0 ) {
+                            $data_to_export[] = array(
+                                'group_id'    => 'wcal_carts',
+                                'group_label' => __( 'Abandoned Carts', 'woocommerce-abandoned-cart' ),
+                                'item_id'     => 'cart-' . $cart_id,
+                                'data'        => self::get_cart_data( $cart_id ),
+                            );
+                        }
+                    }
+                    $done = $page > count( $cart_chunks );
+                } else {
+                    $done = true;
+                }
+            } else {
+                $done = true;
+            }
+            
+            return array(
+                'data' => $data_to_export,
+                'done' => $done,
+            );
+    
+        }
+        
+        /**
+         * Returns the personal data for each abandoned cart
+         * 
+         * @param integer $abandoned_id - Abandoned Cart ID
+         * @return array $personal_data - Personal data to be displayed
+         * @global $wpdb
+         * @since  4.9
+         */
+        static function get_cart_data( $abandoned_id ) {
+            $personal_data   = array();
+            
+            global $wpdb;
+            
+            $cart_query = "SELECT * FROM `" . $wpdb->prefix . 'ac_abandoned_cart_history_lite' . "`
+                            WHERE id = %d";
+            $cart_details = $wpdb->get_results( $wpdb->prepare( $cart_query, $abandoned_id ) );
+            $cart_details = $cart_details[0];
+
+           if( $user_type == 'GUEST' ) {
+
+            $cart_details_to_export = apply_filters( 'wcal_personal_export_cart_details_prop', array(
+                'cart_id'                    => __( 'Abandoned Cart ID', 'woocommerce-abandoned-cart' ),
+                'date_created'               => __( 'Abandoned Date', 'woocommerce-abandoned-cart' ),
+                'cart_status'                => __( 'Abandoned Cart Status', 'woocommerce-abandoned-cart' ),
+                'total'                      => __( 'Cart Total', 'woocommerce-abandoned-cart' ),
+                'items'                      => __( 'Items Present', 'woocommerce-abandoned-cart' ),
+                'session_id'                 => __( 'Session ID', 'woocommerce-abandoned-cart' ),
+                'formatted_billing_address'  => __( 'Billing Address', 'woocommerce-abandoned-cart' ),
+                'billing_email'              => __( 'Email Address', 'woocommerce-abandoned-cart' ),
+            ), $abandoned_id );
+           
+           } else {
+            $cart_details_to_export = apply_filters( 'wcal_personal_export_cart_details_prop', array(
+                'cart_id'                    => __( 'Abandoned Cart ID', 'woocommerce-abandoned-cart' ),
+                'date_created'               => __( 'Abandoned Date', 'woocommerce-abandoned-cart' ),
+                'cart_status'                => __( 'Abandoned Cart Status', 'woocommerce-abandoned-cart' ),
+                'total'                      => __( 'Cart Total', 'woocommerce-abandoned-cart' ),
+                'items'                      => __( 'Items Present', 'woocommerce-abandoned-cart' ),
+                'formatted_billing_address'  => __( 'Billing Address', 'woocommerce-abandoned-cart' ),
+                'billing_email'              => __( 'Email Address', 'woocommerce-abandoned-cart' ),
+            ), $abandoned_id );
+            
+           }         
+            $user_id = $cart_details->user_id;
+            $user_type = $cart_details->user_type;
+            
+            if( $user_type == 'GUEST' ) {
+                $guest_details = self::wcal_get_guest_personal_info( $user_id );
+            }
+            foreach( $cart_details_to_export as $prop => $name ) {
+
+                $cart_data = json_decode( stripslashes( $cart_details->abandoned_cart_info ) );
+                $cart_info = $cart_data->cart;
+                
+                if( count( $cart_info ) > 0 ) {
+                    $cart_details_formatted = wcal_common::wcal_get_cart_details( $cart_info );
+                }
+                
+                switch( $prop ) {
+                    case 'cart_id':
+                        $value = $cart_details->id;
+                        break;
+                    case 'date_created':
+                        $value = date( 'Y-m-d H:i:s', $cart_details->abandoned_cart_time );
+                        break;
+                    case 'cart_status':
+                        
+                        $cart_ignored = $cart_details->cart_ignored;
+                        
+                        switch( $cart_ignored ) {
+                            case '0':
+                                $value =  $cart_details->recovered_cart > 0  ? __( "Cart Recovered - Order #", 'woocommerce-abandoned-cart' ) . $cart_details->recovered_cart : __( 'Abandoned', 'woocommerce-abandoned-cart' );
+                                break;
+                            case '1':
+                                $value = $cart_details->recovered_cart > 0  ? __( "Cart Recovered - Order #", 'woocommerce-abandoned-cart' ) . $cart_details->recovered_cart : __( 'Abandoned but new cart created', 'woocommerce-abandoned-cart' );
+                                break;
+                            case '2':
+                                $value = __( 'Abandoned - Order Unpaid (Order #', 'woocommerce-abandoned-cart') . $cart_details->recovered_cart . ")";
+                                break;
+                        }
+                        break;
+                    case 'total':
+                        $total = 0;
+                        
+                        if( count( $cart_info ) > 0 ) {
+                            foreach( $cart_info as $k => $v ) {
+                        
+                                $total += $cart_details_formatted[$k][ 'item_total' ];
+                            }
+                        }
+                        $value = wc_price( $total );
+                        break;
+                    case 'items':
+                        $value = '';
+                        
+                        if( count( $cart_info ) > 0 ) {
+                            foreach( $cart_info as $k => $v ) {
+                        
+                                $product_name = $cart_details_formatted[$k][ 'product_name' ];
+                                $qty = $cart_details_formatted[$k][ 'qty' ];
+                        
+                                $value .= ( $value == '' ) ? "$product_name x $qty" : ", $product_name x $qty";
+                            }
+                        }
+                        break;
+                    case 'formatted_billing_address':
+                        
+                        if( $user_type == 'REGISTERED' ) { // registered user
+                            
+                            $billing = wcal_common::wcal_get_billing_details( $user_id );
+                            $value = get_user_meta( $user_id, 'billing_first_name', true ); // First Name
+                            $value .= ' ' . get_user_meta( $user_id, 'billing_last_name', true ); // Last Name 
+                            if( count( $billing ) > 0 ) {
+                                foreach( $billing as $details ) {
+                                    if( $details != '' ) {
+                                        $value .= ",$details ";
+                                    } 
+                                }
+                                
+                            }
+                        } elseif ( $user_type == 'GUEST' ) {
+                            if( count( $guest_details ) > 0 ) {
+                                $value = $guest_details->billing_first_name; // First Name
+                                $value .= ' ' . $guest_details->billing_last_name; // Last Name
+                            }
+                        }
+                        break;
+                    
+                    case 'billing_email':
+                        if( $user_type == 'REGISTERED' ) { // registered user
+                            $value = get_user_meta( $user_id, $prop, true );
+                        } else if( $user_type == 'GUEST' ) {
+                            if( count( $guest_details ) > 0 ) {
+                                $value = $guest_details->$prop; 
+                            }
+                        }
+                        break;
+                    default:
+                        $value = ( isset( $cart_details->$prop ) ) ? $cart_details->$prop : '';
+                        break;
+                }
+                
+                $value = apply_filters( 'wcal_personal_export_cart_details_prop_value', $value, $prop, $cart_details );
+                
+                $personal_data[] = array( 
+                    'name' => $name,
+                    'value' => $value,
+                );
+            
+            }
+            $personal_data = apply_filters( 'wcal_personal_data_cart_details_export', $personal_data, $cart_details );
+            
+            return $personal_data;
+        }
+        
+        /**
+         * Returns the personal data from the plugin guest cart table
+         * for guest abandoned carts
+         * 
+         * @param integer $user_id - User ID
+         * @return array $guest_details - Guest personal details
+         * @global $wpdb
+         * @since  4.9
+         */
+        static function wcal_get_guest_personal_info( $user_id ) {
+            global $wpdb;
+            $guest_details = array();
+            
+            $guest_query = "SELECT billing_first_name, billing_last_name, email_id AS billing_email, phone AS billing_phone FROM `" . $wpdb->prefix . 'ac_guest_abandoned_cart_history_lite' . "`
+                            WHERE id = %d";
+            
+            $guest_details = $wpdb->get_results( $wpdb->prepare( $guest_query, $user_id ) );
+            
+            if( is_array( $guest_details ) && count( $guest_details ) > 0 ) {
+                $guest_details = $guest_details[0];
+            }
+            
+            return $guest_details;
+        }
+    } // end of class
+    $Wcal_Personal_Data_Export = new Wcal_Personal_Data_Export();
+} // end if
+?>

--- a/woocommerce-abandoned-cart/includes/wcal_data_tracking_message.php
+++ b/woocommerce-abandoned-cart/includes/wcal_data_tracking_message.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * This class will add messages as needed informing users of data being tracked.
+ * @author   Tyche Softwares
+ * @package  Abandoned-Cart-Lite-for-WooCommerce/Tracking
+ * @since    4.9
+ */
+if (!defined('ABSPATH')) {
+    exit; // Exit if accessed directly.
+}
+if ( !class_exists('Wcal_Tracking_msg' ) ) {
+
+    /**
+     * It will add messages as needed informing users of data being tracked.
+     * @since    4.9
+     */
+    class Wcal_Tracking_msg {
+        
+        public function __construct() {
+            // Checkout page notice for guest users
+            add_filter( 'woocommerce_checkout_fields' , array( &$this, 'wcal_add_gdpr_msg' ), 10, 1 );
+            // Product page notice for logged in users
+            add_action( 'woocommerce_after_add_to_cart_button', array( &$this, 'wcal_add_logged_msg' ), 10 );
+            // Shop Page notice
+            add_action( 'woocommerce_before_shop_loop', array( &$this, 'wcal_add_logged_msg' ), 10 );
+            add_action( 'woocommerce_after_shop_loop_item', array( &$this, 'wcal_add_logged_msg' ), 10 );
+        }
+        
+        /**
+         * Adds a message to be displayed above Billing_email
+         * field on Checkout page for guest users.
+         * 
+         * @param array $fields - List of fields on Checkout page
+         * @return array $fields - List of fields on Checkout page
+         * 
+         * @hook woocommerce_checkout_fields
+         * @since 4.9
+         */
+        static function wcal_add_gdpr_msg( $fields ) {
+            
+            if( ! is_user_logged_in() ) {
+                // check if any message is present in the settings
+                $guest_msg = get_option( 'wcal_guest_cart_capture_msg' );
+                
+                if( isset( $guest_msg ) && '' != $guest_msg ) {
+                    $existing_label = $fields[ 'billing' ][ 'billing_email' ][ 'label' ];
+                    $fields[ 'billing' ][ 'billing_email' ][ 'label' ] = $existing_label . "<br><small>$guest_msg</small>";
+                }
+            }
+            return $fields;
+        }
+        
+        /**
+         * Adds a message to be displayed for logged in users
+         * Called on Shop & Product page
+         * 
+         * @hook woocommerce_after_add_to_cart_button
+         *       woocommerce_before_shop_loop
+         * @since 4.9      
+         */
+        static function wcal_add_logged_msg() {
+            if( is_user_logged_in() ) {
+                
+                $registered_msg = get_option( 'wcal_logged_cart_capture_msg' );
+                
+                if( isset( $registered_msg ) && '' != $registered_msg ) {
+                    echo "<p><small>" . __( $registered_msg, 'woocommerce-abandoned-cart' ) . "</small></p>";
+                }
+            }
+        }
+        
+    } // end of class
+    $Wcal_Tracking_msg = new Wcal_Tracking_msg();
+} // end IF


### PR DESCRIPTION
1) Added  2 settings for guest users and logged-in users to displayed
the message when tracking their carts under General setting tab.

If the setting will be blank then we do not show the notice and data
will be tracked.

If Admin adds the notice then we will show the notice on Email Address
field for guest users and on every Add to Cart button  for logged-in
users.

2) Added the privacy exporter and eraser files.

3) These will be called when personal data is exported or erased from WP
Dashboard->Tools->Export Personal data & WP Dashboard->Tools->Erase
Personal Data

4) Personal data will be erased based on the WooCommerce setting
Woocommerce->Settings->Accounts & Privacy->Remove personal data from
orders is set to on