### PR TITLE
Fix #346

### DIFF
--- a/woocommerce-abandoned-cart/includes/admin/wcal_privacy_erase.php
+++ b/woocommerce-abandoned-cart/includes/admin/wcal_privacy_erase.php
@@ -86,9 +86,13 @@ if ( !class_exists('Wcal_Personal_Data_Eraser' ) ) {
                 
                 $guest_user_ids = $wpdb->get_results( $wpdb->prepare( $guest_query, $email_address ) );
                 
-                if( count( $guest_user_ids ) == 0 ) 
-                    return;
-                
+                if( count( $guest_user_ids ) == 0 ) {
+                    return array( 'messages' => array( __( 'No personal data found for any abandoned carts.', 'woocommerce-abandoned-cart' ) ),
+                            'items_removed' => false,
+                            'items_retained' => true,       
+                            'done' => true
+                    );
+                }
                 $cart_ids = array();
                 
                 foreach( $guest_user_ids as $ids ) {

--- a/woocommerce-abandoned-cart/includes/admin/wcal_privacy_export.php
+++ b/woocommerce-abandoned-cart/includes/admin/wcal_privacy_export.php
@@ -88,7 +88,10 @@ if ( !class_exists('Wcal_Personal_Data_Export' ) ) {
                 $guest_user_ids = $wpdb->get_results( $wpdb->prepare( $guest_query, $email_address ) );
                 
                 if( count( $guest_user_ids ) == 0 ) 
-                    return;
+                    return array(
+                       'data' => array(),
+                       'done' => true,
+                    );
                 
                 $cart_ids = array();
                 


### PR DESCRIPTION
When personal data is exported or erased and no personal data of
abandoned cart is found for the user, an error is thrown due the data
returned by the plugin.

Tests should be run for both registered as well as guest email
addresses.