### PR TITLE
Fix #168 and Fix #120

### DIFF
--- a/woocommerce-abandoned-cart/includes/wcal_class-guest.php
+++ b/woocommerce-abandoned-cart/includes/wcal_class-guest.php
@@ -165,19 +165,14 @@ if ( ! class_exists( 'woocommerce_guest_ac' ) ) {
                 foreach ( $results_guest as $key => $value ) {
                     $query = "SELECT * FROM `".$wpdb->prefix."ac_abandoned_cart_history_lite`
                               WHERE  user_id = %d AND recovered_cart = '0'" ;
-                    $result = $wpdb->get_results( $wpdb->prepare( $query, $value->id ) );  
+                    $result = $wpdb->get_results( $wpdb->prepare( $query, $value->id ) ); 
+                    // update existing record and create new record if guest cart history table will have the same email id. 
                     
                     if ( count( $result ) ) {
-                        $delete_sent_email = "DELETE FROM `".$wpdb->prefix."ac_sent_history_lite` 
-                                              WHERE abandoned_order_id = '".$result[0]->id."'";
-                        $wpdb->query( $delete_sent_email );						
-                        $delete_query = "DELETE FROM `".$wpdb->prefix."ac_abandoned_cart_history_lite` 
-                                         WHERE user_id = '".$value->id."'";
-                        $wpdb->query( $delete_query );
+                         $update_mobile_info = "UPDATE `" .$wpdb->prefix."ac_abandoned_cart_history_lite` SET cart_ignored = '1' WHERE user_id = '".$value->id."'";
+                        $wpdb->query( $update_mobile_info );
+                        
                     }
-                    $guest_delete = "DELETE FROM `".$wpdb->prefix."ac_guest_abandoned_cart_history_lite` 
-                                    WHERE id = '".$value->id."'";
-                    $wpdb->query( $guest_delete );
                 }
             }
             // Insert record in guest table

--- a/woocommerce-abandoned-cart/woocommerce-ac.php
+++ b/woocommerce-abandoned-cart/woocommerce-ac.php
@@ -2495,7 +2495,7 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                             </form>
                         </div>                        
                         <?php 
-                  } elseif ( ( $action == 'emailtemplates' && ( $mode != 'edittemplate' && $mode != 'addnewtemplate' ) ) || ( $action == 'emailtemplates' || '' == $action || '-1' == $action || '-1' == $action_two ) ) {
+                  } elseif ( ( $action == 'emailtemplates' && ( $mode != 'edittemplate' && $mode != 'addnewtemplate' ) || '' == $action || '-1' == $action || '-1' == $action_two ) ) {
                         ?>                                                  
                         <p> <?php _e( 'Add email templates at different intervals to maximize the possibility of recovering your abandoned carts.', 'woocommerce-abandoned-cart' );?> </p>
                         <?php                       


### PR DESCRIPTION
If the abandoned cart will have the same email ID record then we will
not delete that record. We will change the status of the existing cart
to "Abandoned but new cart created after this" on Abandoned Orders tab.