### PR TITLE
Added new setting for the deletion of Abandoned Carts.

### DIFF
--- a/woocommerce-abandoned-cart/includes/wcal_actions.php
+++ b/woocommerce-abandoned-cart/includes/wcal_actions.php
@@ -55,4 +55,55 @@ class wcal_delete_bulk_action_handler {
          
         wp_safe_redirect( admin_url( '/admin.php?page=woocommerce_ac_page&action=emailtemplates&wcal_template_deleted=YES' ) );
     }
+
+        /**
+         * It will delete cart automatically after X days
+         * @hook admin_init
+         * @globals mixed $wpdb
+         * @since 5.0
+         */
+        public static function wcal_delete_abandoned_carts_after_x_days() {
+            global $wpdb;
+            $query = "SELECT * FROM `" . $wpdb->prefix . "ac_abandoned_cart_history_lite" . "` WHERE recovered_cart = '0' ";
+            $carts = $wpdb->get_results ( $query );
+            foreach( $carts as $cart_key => $cart_value ) {
+                $cart_update_time = $cart_value->abandoned_cart_time;
+                wcal_delete_bulk_action_handler::wcal_delete_ac_carts( $cart_value, $cart_update_time );
+            }
+        }
+    /**
+         * It will delete the abandoned cart data from database.
+         * It will also delete the email history for that abandoned cart.
+         * If the user id guest user then it will delete the record from users table.
+         * @param object $value Value of cart.
+         * @param timestamp $cart_update_time Cart abandoned time
+         * @globals mixed $wpdb
+         * @since 5.0
+         */
+        public static function wcal_delete_ac_carts( $value, $cart_update_time ) {
+            global $wpdb;
+            $delete_ac_after_days      = get_option( 'ac_lite_delete_abandoned_order_days' );
+            if ( '' != $delete_ac_after_days ){
+                $delete_ac_after_days_time = $delete_ac_after_days * 86400;
+                $current_time              = current_time( 'timestamp' );
+                $check_time                = $current_time - $cart_update_time;
+
+                if ( $check_time > $delete_ac_after_days_time && $delete_ac_after_days_time != 0 && $delete_ac_after_days_time != "" ) {
+                    $abandoned_id                = $value->id;
+                    $query_delete_sent_history   = "DELETE FROM `" . $wpdb->prefix . "ac_sent_history_lite" . "` WHERE abandoned_order_id = '$abandoned_id' ";
+                    $delete_sent_history         = $wpdb->get_results( $query_delete_sent_history );
+
+                    $user_id               = $value->user_id;
+                    $query                 = "DELETE FROM `" .  $wpdb->prefix . "ac_abandoned_cart_history_lite" . "` WHERE user_id = '$user_id' AND abandoned_cart_time = '$cart_update_time'";
+                    $results2              = $wpdb->get_results ( $query );
+
+                    $query_delete_cart     = "DELETE FROM `" . $wpdb->prefix."usermeta` WHERE user_id = '$user_id' AND meta_key = '_woocommerce_persistent_cart' ";
+                    $results_delete        = $wpdb->get_results ( $query_delete_cart );
+                    if ( $user_id >= '63000000' ) {
+                        $guest_query   = "DELETE FROM `" . $wpdb->prefix . "ac_guest_abandoned_cart_history_lite" . "` WHERE id = '" . $user_id . "'";
+                        $results_guest = $wpdb->get_results ( $guest_query );
+                    }
+                }
+            }
+        }
 }


### PR DESCRIPTION
I have added new feature in the plugin. We will allow to customers to
delete the carts automatically after number of days.

We have added "Automatically Delete Abandoned Orders after X days" in
the "Settings" tab.

This will delete the abandoned carts from Abandoned Orders tab after the
number of days which is set in the setting.

It will also delete the record from database for sent emails.