### PR TITLE
Changed URL in Deactivation survey

### DIFF
--- a/woocommerce-abandoned-cart/includes/component/deactivate-survey-popup/class-ts-deactivation.php
+++ b/woocommerce-abandoned-cart/includes/component/deactivate-survey-popup/class-ts-deactivation.php
@@ -16,7 +16,7 @@ class Wcal_TS_deactivate {
 	 * @var string
 	 */
 
-	private static $api_url = 'http://trackingdev.tychesoftwares.com/v1/';
+	private static $api_url = 'http://tracking.tychesoftwares.com/v1/';
 
 	/**
 	* @var string Plugin name


### PR DESCRIPTION
Once we deactivate the plugin then we are checking for deactivation
survey.
When we deactivate the plugin, the data of the
deactivation were moved to the Development site.

I have changed URL to
Live site and it will be passed to the database of the live site now.