### PR TITLE
Bugfix/wp load

### DIFF
--- a/woocommerce-abandoned-cart/cron/wcal_send_email.php
+++ b/woocommerce-abandoned-cart/cron/wcal_send_email.php
@@ -19,6 +19,12 @@ if ( ! isset( $wp_load ) ) {
             break;
         }
     }
+    /*
+     * In case wp-content folder is seperated from WP core folders (like Bedrock setup from Roots.io) the above while loop will not find wp-load correctly, so we must use ABSPATH
+     */
+    if ( ! file_exists( $wp_load ) ) {
+        $wp_load = trailingslashit( ABSPATH ) . 'wp-load.php';
+    }
 }
 $wcal_root = dirname( dirname(__FILE__) ); // go two level up for directory from this file.
 require_once $wp_load;

--- a/woocommerce-abandoned-cart/cron/wcal_send_email.php
+++ b/woocommerce-abandoned-cart/cron/wcal_send_email.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * It will send the automatic reminder emails to the customers.
  *
@@ -38,12 +38,12 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
      * It will send the automatic reminder emails to the customers
      * @since 1.3
      */
-    class woocommerce_abandon_cart_cron {   
+    class woocommerce_abandon_cart_cron {
         var $cart_settings_cron;
-        var $cart_abandon_cut_off_time_cron;        
-        public function __construct() {         
-            $this->cart_settings_cron = get_option( 'ac_lite_cart_abandoned_time' );            
-            $this->cart_abandon_cut_off_time_cron = ( $this->cart_settings_cron ) * 60;             
+        var $cart_abandon_cut_off_time_cron;
+        public function __construct() {
+            $this->cart_settings_cron = get_option( 'ac_lite_cart_abandoned_time' );
+            $this->cart_abandon_cut_off_time_cron = ( $this->cart_settings_cron ) * 60;
         }
         /**
          * It will send the reminder emails to the cutomers.
@@ -53,15 +53,15 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
          * @globals mixed $woocommerce
          * @since 1.3
          */
-        function wcal_send_email_notification() {   
-            global $wpdb, $woocommerce;         
+        function wcal_send_email_notification() {
+            global $wpdb, $woocommerce;
             //Grab the cart abandoned cut-off time from database.
-            $cart_settings             = get_option( 'ac_lite_cart_abandoned_time' );           
-            $cart_abandon_cut_off_time = $cart_settings * 60;       
+            $cart_settings             = get_option( 'ac_lite_cart_abandoned_time' );
+            $cart_abandon_cut_off_time = $cart_settings * 60;
             //Fetch all active templates present in the system
             $query        = "SELECT wpet . * FROM `".$wpdb->prefix."ac_email_templates_lite` AS wpet
                              WHERE wpet.is_active = '1' ORDER BY `day_or_hour` DESC, `frequency` ASC ";
-            $results      = $wpdb->get_results( $query );       
+            $results      = $wpdb->get_results( $query );
             $hour_seconds = 3600;   // 60 * 60
             $day_seconds  = 86400; // 24 * 60 * 60
             foreach ( $results as $key => $value ) {
@@ -69,10 +69,10 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                     $time_to_send_template_after = $value->frequency * $day_seconds;
                 } elseif ( $value->day_or_hour == 'Hours' ) {
                     $time_to_send_template_after = $value->frequency * $hour_seconds;
-                }               
+                }
                 $carts               = $this->wcal_get_carts( $time_to_send_template_after, $cart_abandon_cut_off_time );
                 $email_frequency     = $value->frequency;
-                $email_body_template = $value->body;            
+                $email_body_template = $value->body;
                 $email_subject       = stripslashes  ( $value->subject );
                 $email_subject       = convert_smilies ( $email_subject );
                 $wcal_from_name      = get_option ( 'wcal_from_name' );
@@ -91,7 +91,7 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                 $is_wc_template      = $value->is_wc_template;
                 $wc_template_header_text = $value->wc_email_header != '' ? $value->wc_email_header : __( 'Abandoned cart reminder', 'woocommerce-abandoned-cart');
                 $wc_template_header  = stripslashes( $wc_template_header_text );
-                if ( '' != $email_body_template ) { 
+                if ( '' != $email_body_template ) {
                     foreach ( $carts as $key => $value ) {
 
                         $wcal_is_guest_id_correct = $this->wcal_get_is_guest_valid ( $value->user_id, $value->user_type ) ;
@@ -99,7 +99,7 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
 
                             if ( $value->user_type == "GUEST" && $value->user_id != '0' ) {
                                 $value->user_login = "";
-                                $query_guest       = "SELECT billing_first_name, billing_last_name, email_id FROM `".$wpdb->prefix."ac_guest_abandoned_cart_history_lite` 
+                                $query_guest       = "SELECT billing_first_name, billing_last_name, email_id FROM `".$wpdb->prefix."ac_guest_abandoned_cart_history_lite`
                                                     WHERE id = %d";
                                 $results_guest     = $wpdb->get_results( $wpdb->prepare( $query_guest, $value->user_id ) );
                                 if ( count( $results_guest ) > 0 && isset( $results_guest[0]->email_id ) ) {
@@ -111,7 +111,7 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                                 }
                                 $key                = 'billing_email';
                                 $single             = true;
-                                $user_biiling_email = get_user_meta( $user_id, $key, $single );                         
+                                $user_biiling_email = get_user_meta( $user_id, $key, $single );
                                 if ( isset( $user_biiling_email ) && $user_biiling_email != '' ) {
                                    $value->user_email = $user_biiling_email;
                                 }
@@ -125,43 +125,43 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                             }
                             if( count( get_object_vars( $cart ) ) > 0 && isset( $value->user_id ) && '0' != $value->user_id && isset( $value->id ) ) {
                                 $cart_update_time = $value->abandoned_cart_time;
-                                $new_user         = $this->wcal_check_sent_history( $value->user_id, $cart_update_time, $template_id, $value->id );                         
+                                $new_user         = $this->wcal_check_sent_history( $value->user_id, $cart_update_time, $template_id, $value->id );
                                 if ( $new_user == true ) {
 
                                  /**
-                                  * When there are 3 templates and for cart id 1 all template time has been reached. BUt all templates 
+                                  * When there are 3 templates and for cart id 1 all template time has been reached. BUt all templates
                                   * are deactivated.
                                   * If we activate all 3 template then at a 1 time all 3 email templates send to the users.
-                                  * So below function check that after first email is sent time and then from that time it will send the 
+                                  * So below function check that after first email is sent time and then from that time it will send the
                                   * 2nd template time.  ( It will not consider the cart abadoned time in this case. )
                                   */
 
                                 $wcal_check_cart_needed_for_multiple_template = $this->wcal_remove_cart_for_mutiple_templates( $value->id, $time_to_send_template_after, $template_id );
 
                                 /**
-                                 * When we click on the place order button, we check if the order is placed after the 
-                                 * cut off time. And if yes then if the status of the order is pending or falied then 
-                                 * we keep it as the abandonoed and we need to send reminder emails. So in below function 
-                                 * we first check if any order is placed with todays date then we do not send the 
-                                 * reminder email. But what if placed order status is pending or falied? So this 
-                                 * condition will not call that function andthe reminder email will be sent. 
+                                 * When we click on the place order button, we check if the order is placed after the
+                                 * cut off time. And if yes then if the status of the order is pending or falied then
+                                 * we keep it as the abandonoed and we need to send reminder emails. So in below function
+                                 * we first check if any order is placed with todays date then we do not send the
+                                 * reminder email. But what if placed order status is pending or falied? So this
+                                 * condition will not call that function andthe reminder email will be sent.
                                  */
 
                                 $wcal_check_if_cart_is_present_in_post_meta   = "SELECT wpm.post_id, wpost.post_date, wpost.post_status  FROM `" . $wpdb->prefix . "postmeta` AS wpm
-                                    LEFT JOIN `" . $wpdb->prefix . "posts` AS wpost 
+                                    LEFT JOIN `" . $wpdb->prefix . "posts` AS wpost
                                     ON wpm.post_id = wpost.ID
-                                    WHERE wpm.meta_key = 'wcap_recover_order_placed' AND 
-                                    wpm.meta_value = %s AND wpm.post_id = wpost.ID AND 
-                                    wpost.post_type = 'shop_order' 
+                                    WHERE wpm.meta_key = 'wcap_recover_order_placed' AND
+                                    wpm.meta_value = %s AND wpm.post_id = wpost.ID AND
+                                    wpost.post_type = 'shop_order'
                                     ORDER BY wpm.post_id   DESC LIMIT 1";
 
                                 $results_wcal_check_if_cart_is_present_in_post_meta = $wpdb->get_results( $wpdb->prepare( $wcal_check_if_cart_is_present_in_post_meta, $value->id  ) );
 
                                 $wcap_check_cart_staus_need_to_update = false;
 
-                                if ( empty ($results_wcal_check_if_cart_is_present_in_post_meta) || 
-                                ( isset( $results_wcal_check_if_cart_is_present_in_post_meta[0] ) && 
-                                    $results_wcal_check_if_cart_is_present_in_post_meta[0]->post_status != "wc-failed" &&     
+                                if ( empty ($results_wcal_check_if_cart_is_present_in_post_meta) ||
+                                ( isset( $results_wcal_check_if_cart_is_present_in_post_meta[0] ) &&
+                                    $results_wcal_check_if_cart_is_present_in_post_meta[0]->post_status != "wc-failed" &&
                                     $results_wcal_check_if_cart_is_present_in_post_meta [0]->post_status != "wc-pending" ) ){
 
                                     $wcap_check_cart_staus_need_to_update = woocommerce_abandon_cart_cron::wcal_update_abandoned_cart_status_for_placed_orders ( $time_to_send_template_after,  $cart_update_time, $value->user_id, $value->user_type, $value->id, $value->user_email );
@@ -171,17 +171,17 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                                      false == $wcap_check_cart_staus_need_to_update ) {
 
                                     $cart_info_db = $value->abandoned_cart_info;
-                                    $email_body   = $email_body_template;  
+                                    $email_body   = $email_body_template;
                                     $wcal_check_cart_total = $this->wcal_check_cart_total( $cart );
                                     if( true == $wcal_check_cart_total ) {
                                         if ( $value->user_type == "GUEST" ) {
                                             if ( isset( $results_guest[0]->billing_first_name ) ) {
                                                 $email_body    = str_replace( "{{customer.firstname}}", $results_guest[0]->billing_first_name, $email_body );
                                                 $email_subject = str_replace( "{{customer.firstname}}", $results_guest[0]->billing_first_name, $email_subject );
-                                            }                           
+                                            }
                                             if ( isset( $results_guest[0]->billing_last_name ) ) {
                                                 $email_body = str_replace( "{{customer.lastname}}", $results_guest[0]->billing_last_name, $email_body );
-                                            }                               
+                                            }
                                             if ( isset( $results_guest[0]->billing_first_name ) && isset( $results_guest[0]->billing_last_name ) ) {
                                                 $email_body = str_replace( "{{customer.fullname}}", $results_guest[0]->billing_first_name." ".$results_guest[0]->billing_last_name, $email_body );
                                             }
@@ -192,7 +192,7 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                                                 $email_body = str_replace( "{{customer.fullname}}", $results_guest[0]->billing_last_name, $email_body );
                                             }
                                         } else {
-                                            $user_first_name      = '';                                 
+                                            $user_first_name      = '';
                                             $user_first_name_temp = get_user_meta( $value->user_id, 'billing_first_name', true );
                                             if( isset( $user_first_name_temp ) && "" == $user_first_name_temp ) {
                                                 $user_data       = get_userdata( $user_id );
@@ -203,9 +203,9 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                                                 }
                                             } else {
                                                 $user_first_name = $user_first_name_temp;
-                                            }                                   
-                                            $email_body          = str_replace( "{{customer.firstname}}", $user_first_name, $email_body );                     
-                                            $email_subject       = str_replace( "{{customer.firstname}}", $user_first_name, $email_subject );                      
+                                            }
+                                            $email_body          = str_replace( "{{customer.firstname}}", $user_first_name, $email_body );
+                                            $email_subject       = str_replace( "{{customer.firstname}}", $user_first_name, $email_subject );
                                             $user_last_name      = '';
                                             $user_last_name_temp = get_user_meta( $value->user_id, 'billing_last_name', true );
                                             if( isset( $user_last_name_temp ) && "" == $user_last_name_temp ) {
@@ -218,46 +218,46 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                                             } else {
                                                 $user_last_name = $user_last_name_temp;
                                             }
-                                            $email_body = str_replace( "{{customer.lastname}}", $user_last_name, $email_body );                             
+                                            $email_body = str_replace( "{{customer.lastname}}", $user_last_name, $email_body );
                                             $email_body = str_replace( "{{customer.fullname}}", $user_first_name." ".$user_last_name, $email_body );
-                                        }                               
-                                        $order_date  = "";                        
+                                        }
+                                        $order_date  = "";
                                         if( $cart_update_time != "" && $cart_update_time != 0 ) {
                                             $date_format = date_i18n( get_option( 'date_format' ), $cart_update_time );
                                             $time_format = date_i18n( get_option( 'time_format' ), $cart_update_time );
                                             $order_date = $date_format . ' ' . $time_format;
-                                        }                               
-                                        $email_body = str_replace( "{{cart.abandoned_date}}", $order_date, $email_body );                               
+                                        }
+                                        $email_body = str_replace( "{{cart.abandoned_date}}", $order_date, $email_body );
                                         $query_sent = "INSERT INTO `".$wpdb->prefix."ac_sent_history_lite` ( template_id, abandoned_order_id, sent_time, sent_email_id )
                                                        VALUES ( %s, %s, '".current_time( 'mysql' )."', %s )";
-                                            
+
                                         $wpdb->query( $wpdb->prepare( $query_sent, $template_id, $value->id, $value->user_email ) );
-                                        
-                                        $query_id = "SELECT * FROM `".$wpdb->prefix."ac_sent_history_lite` 
+
+                                        $query_id = "SELECT * FROM `".$wpdb->prefix."ac_sent_history_lite`
                                                      WHERE template_id = %s AND abandoned_order_id = %s
                                                      ORDER BY id DESC
-                                                     LIMIT 1 "; 
-                                        $results_sent  = $wpdb->get_results( $wpdb->prepare( $query_id, $template_id, $value->id ) );         
-                                        if ( count( $results_sent ) > 0 ) {                           
+                                                     LIMIT 1 ";
+                                        $results_sent  = $wpdb->get_results( $wpdb->prepare( $query_id, $template_id, $value->id ) );
+                                        if ( count( $results_sent ) > 0 ) {
                                             $email_sent_id = $results_sent[0]->id;
                                         } else {
                                             $email_sent_id = '';
                                         }
 
                                         if ( '' != $email_sent_id ) {
-                                        
+
                                             if( $woocommerce->version < '2.3' ) {
                                                 $cart_page_link = $woocommerce->cart->get_cart_url();
                                             } else {
                                                 $cart_page_id   = wc_get_page_id( 'cart' );
                                                 $cart_page_link = $cart_page_id ? get_permalink( $cart_page_id ) : '';
                                             }
-                                                
+
                                             $encoding_cart   = $email_sent_id.'&url='.$cart_page_link;
                                             $validate_cart   = $this->wcal_encrypt_validate( $encoding_cart );
                                             $cart_link_track = get_option('siteurl').'/?wcal_action=track_links&validate=' . $validate_cart;
                                             $email_body      = str_replace( "{{cart.link}}", $cart_link_track, $email_body );
-                                            
+
                                             $validate_unsubscribe          = $this->wcal_encrypt_validate( $email_sent_id );
                                             if ( count( $results_sent ) > 0 && isset( $results_sent[0]->sent_email_id ) ) {
                                                 $email_sent_id_address         = $results_sent[0]->sent_email_id;
@@ -288,7 +288,7 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                                                             <th>'.__( "Price", 'woocommerce-abandoned-cart' ).'</th>
                                                             <th>'.__( "Line Subtotal", 'woocommerce-abandoned-cart' ).'</th>
                                                             </tr>';
-                                                }                   
+                                                }
                                                 $cart_details = $cart_info_db_field->cart;
                                                 $cart_total = $item_subtotal = $item_total = 0;
                                                 $sub_line_prod_name = '';
@@ -306,7 +306,7 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                                                         $item_subtotal = $item_subtotal + $v->line_total + $v->line_subtotal_tax;
                                                     } else {
                                                         $item_subtotal = $item_subtotal + $v->line_total;
-                                                    }                               
+                                                    }
                                                     //  Line total
                                                     $item_total         = $item_subtotal;
                                                     $item_subtotal      = $item_subtotal / $quantity_total;
@@ -314,13 +314,13 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                                                     $item_subtotal      = wc_price( $item_subtotal );
                                                     $product            = wc_get_product( $product_id );
                                                     $prod_image         = $product->get_image();
-                                                    $image_url          = wp_get_attachment_url( get_post_thumbnail_id( $product_id ) );                                        
+                                                    $image_url          = wp_get_attachment_url( get_post_thumbnail_id( $product_id ) );
                                                     if ( isset( $v->variation_id ) && '' != $v->variation_id ) {
                                                         $variation_id               = $v->variation_id;
                                                         $variation                  = wc_get_product( $variation_id );
                                                         $name                       = $variation->get_formatted_name() ;
                                                         $explode_all                = explode ( "&ndash;", $name );
-                                                        if( version_compare( $woocommerce->version, '3.0.0', ">=" ) ) {  
+                                                        if( version_compare( $woocommerce->version, '3.0.0', ">=" ) ) {
                                                                 $wcap_sku = '';
                                                                 if ( $variation->get_sku() ) {
                                                                     $wcap_sku = "SKU: " . $variation->get_sku() . "<br>";
@@ -328,8 +328,8 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                                                                 $wcap_get_formatted_variation  =  wc_get_formatted_variation( $variation, true );
 
                                                                 $add_product_name = $product_name . ' - ' . $wcap_sku . $wcap_get_formatted_variation;
-                                                                    
-                                                                $pro_name_variation = (array) $add_product_name;    
+
+                                                                $pro_name_variation = (array) $add_product_name;
                                                             }else{
                                                                 $pro_name_variation = array_slice( $explode_all, 1, -1 );
                                                             }
@@ -370,40 +370,40 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                                                     $email_body    = str_replace( "{{products.cart}}", $var, $email_body );
                                                     $email_subject = str_replace( "{{product.name}}", __( $sub_line_prod_name, 'woocommerce-abandoned-cart' ), $email_subject );
                                                 }
-                                            
+
                                                 $user_email       = $value->user_email;
                                                 $email_body_final = stripslashes( $email_body );
                                                 $email_body_final = convert_smilies( $email_body_final );
                                                 if ( isset( $is_wc_template ) && "1" == $is_wc_template ){
                                                     ob_start();
-                                                                
+
                                                     wc_get_template( 'emails/email-header.php', array( 'email_heading' => $wc_template_header ) );
                                                     $email_body_template_header = ob_get_clean();
-                                            
+
                                                     ob_start();
-                                            
-                                                    wc_get_template( 'emails/email-footer.php' );  
+
+                                                    wc_get_template( 'emails/email-footer.php' );
                                                     $email_body_template_footer = ob_get_clean();
 
-                                                    $site_title = get_bloginfo( 'name' ); 
+                                                    $site_title = get_bloginfo( 'name' );
                                                     $email_body_template_footer     = str_replace( '{site_title}', $site_title, $email_body_template_footer );
-                                            
+
                                                     $final_email_body =  $email_body_template_header . $email_body_final . $email_body_template_footer;
-                                            
+
                                                     wc_mail( $user_email, $email_subject, $final_email_body, $headers );
-                                            
+
                                                 } else {
                                                     wp_mail( $user_email, $email_subject, __( $email_body_final, 'woocommerce-abandoned-cart' ), $headers );
                                                 }
                                             }
-                                        }                                       
+                                        }
                                     }
                                 }
                             }
                         }
                     }
                 }
-            }                   
+            }
         }
 
         /**
@@ -443,7 +443,7 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                 }
             }
             return false;
-        }       
+        }
         /**
          * Get all carts which have the creation time earlier than the one that is passed.
          * @param string | timestamp $template_to_send_after_time Template time
@@ -452,21 +452,21 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
          * @return array | object $results
          * @since 1.3
          */
-        function wcal_get_carts( $template_to_send_after_time, $cart_abandon_cut_off_time ) {   
-            global $wpdb;       
-            $cart_time = current_time( 'timestamp' ) - $template_to_send_after_time - $cart_abandon_cut_off_time;           
+        function wcal_get_carts( $template_to_send_after_time, $cart_abandon_cut_off_time ) {
+            global $wpdb;
+            $cart_time = current_time( 'timestamp' ) - $template_to_send_after_time - $cart_abandon_cut_off_time;
             $cart_ignored = 0;
             $unsubscribe  = 0;
             $query = "SELECT wpac . * , wpu.user_login, wpu.user_email FROM `".$wpdb->prefix."ac_abandoned_cart_history_lite` AS wpac
                       LEFT JOIN ".$wpdb->base_prefix."users AS wpu ON wpac.user_id = wpu.id
                       WHERE cart_ignored = %s AND unsubscribe_link = %s AND abandoned_cart_time < $cart_time
                       ORDER BY `id` ASC ";
-            
-            $results = $wpdb->get_results( $wpdb->prepare( $query, $cart_ignored, $unsubscribe ) );         
-            return $results;        
+
+            $results = $wpdb->get_results( $wpdb->prepare( $query, $cart_ignored, $unsubscribe ) );
+            return $results;
             exit;
         }
-        
+
         /**
          * It will update the abandoned cart staus if the order has been placed before sending the reminder emails.
          * @param string | timestamp $time_to_send_template_after Template time
@@ -477,7 +477,7 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
          * @param string  $wcal_user_email User Email
          * @globals mixed $wpdb
          * @return boolean true | false
-         * @since 4.3 
+         * @since 4.3
          */
         public static function wcal_update_abandoned_cart_status_for_placed_orders( $time_to_send_template_after, $wcal_cart_time, $wcal_user_id, $wcal_user_type, $wcal_cart_id, $wcal_user_email ){
             global $wpdb;
@@ -495,7 +495,7 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
             }
             return false;
         }
-        
+
         /**
          * It will update the Guest users abandoned cart staus if the order has been placed before sending the reminder emails.
          * @param string | int $cart_id Abandoned cart id
@@ -504,7 +504,7 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
          * @param string  $wcal_user_email_address User Email
          * @globals mixed $wpdb
          * @return int 0 | 1
-         * @since 4.3 
+         * @since 4.3
          */
         public static function wcal_update_status_of_guest ( $cart_id, $abandoned_cart_time , $time_to_send_template_after, $wcal_user_email_address ) {
             global $wpdb;
@@ -526,7 +526,7 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                 if ( $order_date == $todays_date ) {
 
                     /**
-                     * in some case the cart is recovered but it is not marked as the recovered. So here we check if any 
+                     * in some case the cart is recovered but it is not marked as the recovered. So here we check if any
                      * record is found for that cart id if yes then update the record respectively.
                      */
                     $wcal_check_email_sent_to_cart = woocommerce_abandon_cart_cron::wcal_get_cart_sent_data ( $cart_id );
@@ -563,14 +563,14 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                 } else if( "wc-pending" == $results_query_email[0]->post_status || "wc-failed" == $results_query_email[0]->post_status ) {
 
                     /**
-                     * If the post status are pending or failed  the send them for abandoned cart reminder emails. 
-                     */  
+                     * If the post status are pending or failed  the send them for abandoned cart reminder emails.
+                     */
                     return 0;
                 }
             }
             return 0;
         }
-        
+
         /**
          * It will update the Loggedin users abandoned cart staus if the order has been placed before sending the reminder emails.
          * @param string | int $cart_id Abandoned cart id
@@ -579,7 +579,7 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
          * @param string  $user_billing_email User Email
          * @globals mixed $wpdb
          * @return int 0 | 1
-         * @since 4.3 
+         * @since 4.3
          */
         public static function wcal_update_status_of_loggedin( $cart_id, $abandoned_cart_time , $time_to_send_template_after, $user_billing_email ) {
             global $wpdb;
@@ -659,56 +659,56 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
          * the time and further email will sent from first email sent time. So all template will not sent at the same time.
          * @param string | int $wcal_cart_id Abandoned cart id
          * @param string | timestamp $time_to_send_template_after Template time
-         * @param string | int $template_id Template id 
+         * @param string | int $template_id Template id
          * @return boolean true | false
          * @globals mixed $wpdb
          * @since 3.1
          */
         public static function wcal_remove_cart_for_mutiple_templates( $wcal_cart_id, $time_to_send_template_after, $template_id ) {
             global $wpdb;
-            
+
             $wcal_get_last_email_sent_time              = "SELECT * FROM `" . $wpdb->prefix . "ac_sent_history_lite` WHERE abandoned_order_id = $wcal_cart_id ORDER BY `sent_time` DESC LIMIT 1";
             $wcal_get_last_email_sent_time_results_list = $wpdb->get_results( $wcal_get_last_email_sent_time );
 
             if( count( $wcal_get_last_email_sent_time_results_list ) > 0 ) {
                 $last_template_send_time   = strtotime( $wcal_get_last_email_sent_time_results_list[0]->sent_time );
                 $second_template_send_time = $last_template_send_time + $time_to_send_template_after ;
-                $current_time_test         = current_time( 'timestamp' );       
+                $current_time_test         = current_time( 'timestamp' );
                 if( $second_template_send_time > $current_time_test ) {
                     return true;
                 }
             }
-            
+
             return false;
         }
         /**
          * This function is used to encode the validate string.
-         * @param string $validate 
+         * @param string $validate
          * @return encoded data $validate_encoded
          * @since 1.3
          */
-        function wcal_encrypt_validate( $validate ) {            
-            $cryptKey         = get_option( 'wcal_security_key' );        
+        function wcal_encrypt_validate( $validate ) {
+            $cryptKey         = get_option( 'wcal_security_key' );
             $validate_encoded = Wcal_Aes_Ctr::encrypt( $validate, $cryptKey, 256 );
             return( $validate_encoded );
         }
-        
+
         /**
          * It will check if the reminder email has been sent to the abandoned cart.
          * @param string | int $user_id User id
          * @param string | timestamp $cart_update_time Abandoned cart time
          * @param string | int $template_id Template id
          * @param string | int $id Abandoned cart id
-         * @globals mixed $wpdb 
+         * @globals mixed $wpdb
          * @return boolean true | false
-         * @since 1.3 
+         * @since 1.3
          */
-        function wcal_check_sent_history( $user_id, $cart_update_time, $template_id, $id ) {            
-            global $wpdb;           
+        function wcal_check_sent_history( $user_id, $cart_update_time, $template_id, $id ) {
+            global $wpdb;
             $query = "SELECT wpcs . * , wpac . abandoned_cart_time , wpac . user_id FROM `".$wpdb->prefix."ac_sent_history_lite` AS wpcs
                       LEFT JOIN ".$wpdb->prefix."ac_abandoned_cart_history_lite AS wpac ON wpcs.abandoned_order_id =  wpac.id
                       WHERE template_id = %s AND wpcs.abandoned_order_id = %d ORDER BY 'id' DESC LIMIT 1 ";
-                
+
             $results = $wpdb->get_results( $wpdb->prepare( $query, $template_id, $id ) );
             if ( count( $results ) == 0 ) {
                 return true;
@@ -716,10 +716,10 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                 return true;
             } else {
                 return false;
-            }       
-        }       
-    }   
-}   
+            }
+        }
+    }
+}
 $woocommerce_abandon_cart_cron = new woocommerce_abandon_cart_cron();
 $woocommerce_abandon_cart_cron->wcal_send_email_notification();
 


### PR DESCRIPTION
There are cases where the wp-content folder is seperated from the other WP folders. Like in the Bedrock Roots.io setup (see https://roots.io/bedrock/).
In that case, finding $wp_load like it is done now in cron/wcal_send_email.php will not find wp-load.php and will cause a fatal error because it is trying to require wp-load.php from a folder which does not exist.
This patch fixes that.