### PR TITLE
Cron in Background Processing

### DIFF
--- a/woocommerce-abandoned-cart/cron/wcal_send_email.php
+++ b/woocommerce-abandoned-cart/cron/wcal_send_email.php
@@ -715,6 +715,4 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
     }   
 }   
 $woocommerce_abandon_cart_cron = new woocommerce_abandon_cart_cron();
-$woocommerce_abandon_cart_cron->wcal_send_email_notification();
-
 ?>

--- a/woocommerce-abandoned-cart/includes/background-processes/wcal-async-request.php
+++ b/woocommerce-abandoned-cart/includes/background-processes/wcal-async-request.php
@@ -1,0 +1,36 @@
+<?php
+if( !class_exists( 'WP_Async_Request' ) ) {
+    include_once( WP_PLUGIN_DIR . '/woocommerce/includes/libraries/wp-async-request.php' );
+    include_once( WP_PLUGIN_DIR . '/woocommerce/includes/libraries/wp-background-process.php' );
+}
+class WCAL_Async_Request extends WP_Async_Request {
+
+	
+
+	/**
+	 * @var string
+	 */
+	protected $action = 'wcal_single_request';
+
+	/**
+	 * Handle
+	 *
+	 * Override this method to perform any actions required
+	 * during the async request.
+	 */
+	protected function handle() {
+
+	    $reminder_method = $_POST[ 'method' ];
+	    
+	    if( isset( $reminder_method ) ) {
+
+	        switch( $reminder_method ) {
+	            case 'emails':
+	                $wcal_cron = new woocommerce_abandon_cart_cron();
+	                $wcal_cron->wcal_send_email_notification();
+                    break;
+	        }
+	    }
+	}
+
+}

--- a/woocommerce-abandoned-cart/includes/background-processes/wcal-background-process.php
+++ b/woocommerce-abandoned-cart/includes/background-processes/wcal-background-process.php
@@ -1,0 +1,52 @@
+<?php
+
+class WCAL_Background_Process extends WP_Background_Process {
+
+	
+
+	/**
+	 * @var string
+	 */
+	protected $action = 'wcal_all_process';
+
+	/**
+	 * Task
+	 *
+	 * Override this method to perform any actions required on each
+	 * queue item. Return the modified item for further processing
+	 * in the next pass through. Or, return false to remove the
+	 * item from the queue.
+	 *
+	 * @param mixed $item Queue item to iterate over
+	 *
+	 * @return mixed
+	 */
+	protected function task( $item ) {
+
+	    if( isset( $item ) ) {
+	        
+	            switch( $item ) {
+	                case 'emails':
+	                    $wcal_cron = new woocommerce_abandon_cart_cron();
+                        $wcal_cron->wcal_send_email_notification();
+	                    break;
+	            }
+	            
+	    } 
+	    return false;
+		
+	}
+
+	/**
+	 * Complete
+	 *
+	 * Override if applicable, but ensure that the below actions are
+	 * performed, or, call parent::complete().
+	 */
+	protected function complete() {
+		parent::complete();
+
+		// Show notice to user or perform some other arbitrary task...
+	}
+	
+}

--- a/woocommerce-abandoned-cart/includes/background-processes/wcal_process_base.php
+++ b/woocommerce-abandoned-cart/includes/background-processes/wcal_process_base.php
@@ -1,0 +1,63 @@
+<?php 
+
+class Wcal_Process_Base {
+    
+    /**
+     * @var WCAL_Background_Process
+     */
+    protected $process;
+    
+    /**
+     * @var WCAL_Async_Request
+     */
+    protected $request;
+    
+    
+    public function __construct() {
+        add_action( 'plugins_loaded', array( $this, 'init' ) );
+        // Hook into that action that'll fire every 15 minutes
+        add_action( 'woocommerce_ac_send_email_action',        array( &$this, 'wcal_process_handler' ), 11 );
+        
+    }
+    
+    public function init() {
+        
+        require_once plugin_dir_path( __FILE__ ) . 'wcal-async-request.php';
+        require_once plugin_dir_path( __FILE__ ) . 'wcal-background-process.php';
+        
+        $this->request    = new WCAL_Async_Request();
+        $this->process    = new WCAL_Background_Process();
+        
+    } 
+    
+    public function wcal_process_handler() {
+        // add any new reminder methods added in the future for cron here
+        $reminders_list = array( 'emails' );
+
+        if( is_array( $reminders_list ) && count( $reminders_list ) > 0 ) {
+            $this->start( $reminders_list );
+        }
+        
+    }
+    
+    public function start( $reminders_list ) {
+        
+        $this->handle_all( $reminders_list ); 
+        
+    }
+    public function handle_single() {
+        
+    }
+    
+    public function handle_all( $list_reminders ) {
+
+     foreach( $list_reminders as $reminders ) {
+         
+         $this->process->push_to_queue( $reminders );
+     }
+        $this->process->save()->dispatch();
+    }
+    
+}
+new Wcal_Process_Base();
+?>

--- a/woocommerce-abandoned-cart/woocommerce-ac.php
+++ b/woocommerce-abandoned-cart/woocommerce-ac.php
@@ -62,23 +62,6 @@ if ( ! wp_next_scheduled( 'woocommerce_ac_send_email_action' ) ) {
 }
 
 /**
- * Hook into that action that'll fire every 15 minutes 
- */
-add_action( 'woocommerce_ac_send_email_action', 'wcal_send_email_cron' );
-
-/**
- * It will add the wcal_send_email.php file which is responsible for sending the abandoned cart reminde emails.
- * @hook woocommerce_ac_send_email_action
- * @since 1.3
- * @package Abandoned-Cart-Lite-for-WooCommerce/Cron
- */
-function wcal_send_email_cron() {
-    //require_once( ABSPATH.'wp-content/plugins/woocommerce-abandoned-cart/cron/send_email.php' );
-    $plugin_dir_path = plugin_dir_path( __FILE__ );
-    require_once( $plugin_dir_path . 'cron/wcal_send_email.php' );
-}
-
-/**
  * This function will delete plugin tables, options and usermeta when we delete the plugin.
  * @hook register_uninstall_hook
  * @globals mixed $wpdb
@@ -235,6 +218,10 @@ if( !class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             
             // Initialize settings
             register_activation_hook ( __FILE__,                        array( &$this, 'wcal_activate' ) );
+
+            // Background Processing for Cron
+            require_once( 'cron/wcal_send_email.php' );
+            require_once( 'includes/background-processes/wcal_process_base.php' );
             
             // WordPress Administration Menu 
             add_action ( 'admin_menu',                                  array( &$this, 'wcal_admin_menu' ) );


### PR DESCRIPTION
Modified the code to ensure that the cron job which sends reminder
emails, now works in the background, thereby reducing the load on
WP-Cron.