### PR TITLE
Incorrect cart count

### DIFF
--- a/woocommerce-abandoned-cart/includes/classes/class-wcal-recover-orders-table.php
+++ b/woocommerce-abandoned-cart/includes/classes/class-wcal-recover-orders-table.php
@@ -230,7 +230,7 @@ class wcal_Recover_Orders_Table extends WP_List_Table {
 		$ac_results       = $wpdb->get_results( $wpdb->prepare( $query_ac, $start_date, $end_date ) );
 		
 		$query_ac_carts   = "SELECT * FROM " . $wpdb->prefix . "ac_abandoned_cart_history_lite 
-		                     WHERE abandoned_cart_time >= %d AND abandoned_cart_time <= %d AND abandoned_cart_time <= '$compare_time' AND abandoned_cart_info NOT LIKE '%$blank_cart_info%' AND abandoned_cart_info NOT LIKE '$blank_cart_info_guest' AND abandoned_cart_info NOT LIKE '$blank_cart' ";
+		                     WHERE abandoned_cart_time >= %d AND abandoned_cart_time <= %d AND abandoned_cart_time <= '$compare_time' AND abandoned_cart_info NOT LIKE '%$blank_cart_info%' AND abandoned_cart_info NOT LIKE '$blank_cart_info_guest' AND abandoned_cart_info NOT LIKE '$blank_cart' AND (cart_ignored <> '1') OR (cart_ignored = '1' AND recovered_cart > 0)";
 		$ac_carts_results = $wpdb->get_results( $wpdb->prepare( $query_ac_carts, $start_date, $end_date ) );
 		
 		$recovered_item   = $recovered_total = $count_carts = $total_value = $order_total = 0;    		

--- a/woocommerce-abandoned-cart/includes/wcal-common.php
+++ b/woocommerce-abandoned-cart/includes/wcal-common.php
@@ -485,22 +485,22 @@ class wcal_common {
     
         switch ( $get_section_result ) {
             case 'wcal_all_abandoned':    
-                $query_ac        = "SELECT COUNT(`id`) as cnt FROM `".$wpdb->prefix."ac_abandoned_cart_history_lite` WHERE ( user_type = 'REGISTERED' AND abandoned_cart_info NOT LIKE '%$blank_cart_info%' AND abandoned_cart_info NOT LIKE '$blank_cart' AND abandoned_cart_time <= '$compare_time' AND recovered_cart = 0 ) OR ( user_type = 'GUEST' AND abandoned_cart_info NOT LIKE '$blank_cart_info_guest' AND abandoned_cart_info NOT LIKE '%$blank_cart_info%' AND abandoned_cart_info NOT LIKE '$blank_cart' AND abandoned_cart_time <= '$compare_time' AND recovered_cart = 0 ) ORDER BY recovered_cart desc ";
+                $query_ac        = "SELECT COUNT(`id`) as cnt FROM `".$wpdb->prefix."ac_abandoned_cart_history_lite` WHERE ( user_type = 'REGISTERED' AND abandoned_cart_info NOT LIKE '%$blank_cart_info%' AND abandoned_cart_info NOT LIKE '$blank_cart' AND abandoned_cart_time <= '$compare_time' AND recovered_cart = 0 AND cart_ignored <> '1') OR ( user_type = 'GUEST' AND abandoned_cart_info NOT LIKE '$blank_cart_info_guest' AND abandoned_cart_info NOT LIKE '%$blank_cart_info%' AND abandoned_cart_info NOT LIKE '$blank_cart' AND abandoned_cart_time <= '$compare_time' AND recovered_cart = 0 AND cart_ignored <> '1') ORDER BY recovered_cart desc ";
                 $return_abandoned_count  = $wpdb->get_var( $query_ac );
                 break;
     
             case 'wcal_all_registered':    
-                $query_ac        = "SELECT COUNT(`id`) FROM `".$wpdb->prefix."ac_abandoned_cart_history_lite` WHERE ( user_type = 'REGISTERED' AND abandoned_cart_info NOT LIKE '%$blank_cart_info%' AND abandoned_cart_info NOT LIKE '$blank_cart' AND abandoned_cart_time <= '$compare_time' AND recovered_cart = 0 ) ORDER BY recovered_cart desc ";
+                $query_ac        = "SELECT COUNT(`id`) FROM `".$wpdb->prefix."ac_abandoned_cart_history_lite` WHERE ( user_type = 'REGISTERED' AND abandoned_cart_info NOT LIKE '%$blank_cart_info%' AND abandoned_cart_info NOT LIKE '$blank_cart' AND abandoned_cart_time <= '$compare_time' AND recovered_cart = 0 AND cart_ignored <> '1') ORDER BY recovered_cart desc ";
                 $return_abandoned_count = $wpdb->get_var( $query_ac );
                 break;
     
             case 'wcal_all_guest':
-                $query_ac        = "SELECT COUNT(`id`) FROM `".$wpdb->prefix."ac_abandoned_cart_history_lite` WHERE ( user_type = 'GUEST' AND abandoned_cart_info NOT LIKE '$blank_cart_info_guest' AND abandoned_cart_info NOT LIKE '%$blank_cart_info%' AND abandoned_cart_info NOT LIKE '$blank_cart' AND abandoned_cart_time <= '$compare_time' AND recovered_cart = 0 AND user_id >= 63000000 ) ORDER BY recovered_cart desc ";
+                $query_ac        = "SELECT COUNT(`id`) FROM `".$wpdb->prefix."ac_abandoned_cart_history_lite` WHERE ( user_type = 'GUEST' AND abandoned_cart_info NOT LIKE '$blank_cart_info_guest' AND abandoned_cart_info NOT LIKE '%$blank_cart_info%' AND abandoned_cart_info NOT LIKE '$blank_cart' AND abandoned_cart_time <= '$compare_time' AND recovered_cart = 0 AND user_id >= 63000000 AND cart_ignored <> '1') ORDER BY recovered_cart desc ";
                 $return_abandoned_count = $wpdb->get_var( $query_ac );
                 break;
     
             case 'wcal_all_visitor':
-                $query_ac        = "SELECT COUNT(`id`) FROM `".$wpdb->prefix."ac_abandoned_cart_history_lite` WHERE ( user_type = 'GUEST' AND abandoned_cart_info NOT LIKE '$blank_cart_info_guest' AND abandoned_cart_info NOT LIKE '%$blank_cart_info%' AND abandoned_cart_info NOT LIKE '$blank_cart' AND abandoned_cart_time <= '$compare_time' AND recovered_cart = 0  AND user_id = 0 ) ORDER BY recovered_cart desc ";
+                $query_ac        = "SELECT COUNT(`id`) FROM `".$wpdb->prefix."ac_abandoned_cart_history_lite` WHERE ( user_type = 'GUEST' AND abandoned_cart_info NOT LIKE '$blank_cart_info_guest' AND abandoned_cart_info NOT LIKE '%$blank_cart_info%' AND abandoned_cart_info NOT LIKE '$blank_cart' AND abandoned_cart_time <= '$compare_time' AND recovered_cart = 0  AND user_id = 0 AND cart_ignored <> '1') ORDER BY recovered_cart desc ";
                 $return_abandoned_count = $wpdb->get_var( $query_ac );   
                 break;
     


### PR DESCRIPTION
The number of carts abandoned is displayed incorrectly on the Abandoned
Order tab and the Recovered Orders tab.

This is due to the changes done for not displaying carts with the status
'Abandoned but new cart created'