### PR TITLE
Fix #428

### DIFF
--- a/woocommerce-abandoned-cart/includes/frontend/wcal_checkout_process.php
+++ b/woocommerce-abandoned-cart/includes/frontend/wcal_checkout_process.php
@@ -255,7 +255,14 @@ if ( !class_exists( 'Wcal_Checkout_Process' ) ) {
 		                $wpdb->delete( $wcal_history_table_name, array( 'id' => $wcal_abandoned_id ) );
 		            }
 		        }
-		    }
+		    }elseif ( 'pending' == $wc_old_status && 'cancelled' == $wc_new_status ) {
+		    	global $wpdb;
+
+		    	$wcal_history_table_name = $wpdb->prefix . 'ac_abandoned_cart_history_lite';
+		    	$wcal_abandoned_id = get_post_meta( $order_id, 'wcal_abandoned_cart_id', true );
+
+				$wpdb->update( $wcal_history_table_name, array( 'cart_ignored' => '1' ), array( 'id' => $wcal_abandoned_id ) );
+			}
 		}
 
 		/**

--- a/woocommerce-abandoned-cart/includes/wcal-common.php
+++ b/woocommerce-abandoned-cart/includes/wcal-common.php
@@ -760,6 +760,9 @@ class wcal_common {
      * @since 7.11.0
      */
     public static function wcal_get_cart_session( $session_key ) {
+        if ( ! is_object( WC()->session ) ) {
+            return false;
+        }
         return WC()->session->get( $session_key );
     }
 


### PR DESCRIPTION
This issue was resulting due to the logic in recovered orders. Cancelled orders will not be sent reminder emails and removed from Abandoned Orders tab