### PR TITLE
Fix #492

### DIFF
--- a/woocommerce-abandoned-cart/woocommerce-ac.php
+++ b/woocommerce-abandoned-cart/woocommerce-ac.php
@@ -3113,7 +3113,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                 $body_email_preview    = str_replace( '{{cart.abandoned_date}}', $test_date, $body_email_preview );             
                 $cart_url              = wc_get_page_permalink( 'cart' );
                 $body_email_preview    = str_replace( '{{cart.link}}', $cart_url, $body_email_preview );
-                $body_email_preview    = str_replace( '{{cart.unsubscribe}}', '<a href=#>unsubscribe</a>', $body_email_preview );               
+                $body_email_preview    = str_replace( '{{cart.unsubscribe}}', '#', $body_email_preview );               
                 $wcal_price            = wc_price( '100' );
                 $wcal_total_price      = wc_price( '200' );
                 if ( class_exists( 'WP_Better_Emails' ) ) {


### PR DESCRIPTION
The new email templates use {{cart.unsubscribe}} merge tag as a part of
a link. Hence there's no need to specifically add <a> tags for
unsubscribe.