### PR TITLE
Fixes for translation strings

### DIFF
--- a/woocommerce-abandoned-cart/cron/wcal_send_email.php
+++ b/woocommerce-abandoned-cart/cron/wcal_send_email.php
@@ -70,7 +70,7 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                 } elseif ( $value->day_or_hour == 'Hours' ) {
                     $time_to_send_template_after = $value->frequency * $hour_seconds;
                 }
-                
+
                 $carts               = $this->wcal_get_carts( $time_to_send_template_after, $cart_abandon_cut_off_time, $value->id );
                 $email_frequency     = $value->frequency;
                 $email_body_template = $value->body;
@@ -356,7 +356,7 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                                                         }
                                                         $var .='<tr align="center">
                                                                 <td> <a href="'.$cart_link_track.'"> <img src="' . $image_url . '" alt="" height="42" width="42" /> </a></td>
-                                                                <td> <a href="'.$cart_link_track.'">'.__( $product_name, 'woocommerce-abandoned-cart' ).'</a></td>
+                                                                <td> <a href="'.$cart_link_track.'">'.$product_name.'</a></td>
                                                                 <td> '.$quantity_total.'</td>
                                                                 <td> '.$item_subtotal.'</td>
                                                                 <td> '.$item_total_display.'</td>
@@ -384,10 +384,10 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                                                     $var .= '</table>
                                                                             ';
                                                     $email_body    = str_replace( "{{products.cart}}", $var, $email_body );
-                                                    $email_subject = str_replace( "{{product.name}}", __( $sub_line_prod_name, 'woocommerce-abandoned-cart' ), $email_subject );
+                                                    $email_subject = str_replace( "{{product.name}}", $sub_line_prod_name, $email_subject );
                                                 }else {
-                                                    $email_body    = str_replace( "{{products.cart}}", 'Product no longer exists', $email_body );
-                                                    $email_subject = str_replace( "{{product.name}}", __( $sub_line_prod_name, 'woocommerce-abandoned-cart' ), $email_subject );
+                                                    $email_body    = str_replace( "{{products.cart}}", __( 'Product no longer exists', 'woocommerce-abandoned-cart' ), $email_body );
+                                                    $email_subject = str_replace( "{{product.name}}", $sub_line_prod_name, $email_subject );
                                                 }
                                             }
 
@@ -413,7 +413,7 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                                                     wc_mail( $user_email, $email_subject, $final_email_body, $headers );
 
                                                 } else {
-                                                    wp_mail( $user_email, $email_subject, __( $email_body_final, 'woocommerce-abandoned-cart' ), $headers );
+                                                    wp_mail( $user_email, $email_subject, $email_body_final, $headers );
                                                 }
                                             }
                                         }
@@ -483,7 +483,7 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
             }
             $cart_ignored = 0;
             $unsubscribe  = 0;
-            $query = "SELECT wpac . * , wpu.user_login, wpu.user_email 
+            $query = "SELECT wpac . * , wpu.user_login, wpu.user_email
                 FROM `".$wpdb->prefix."ac_abandoned_cart_history_lite` AS wpac
                 LEFT JOIN ".$wpdb->base_prefix."users AS wpu ON wpac.user_id = wpu.id
                 WHERE cart_ignored = %s AND unsubscribe_link = %s AND abandoned_cart_time < $cart_time

--- a/woocommerce-abandoned-cart/includes/admin/wcal_privacy_export.php
+++ b/woocommerce-abandoned-cart/includes/admin/wcal_privacy_export.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Export Abandoned Carts data in 
+ * Export Abandoned Carts data in
  * Dashboard->Tools->Export Personal Data
- * 
+ *
  * @since 4.9
  */
 // Exit if accessed directly
@@ -15,107 +15,107 @@ if ( ! class_exists('Wcal_Personal_Data_Export' ) ) {
      * Dashboard->Tools->Export Personal Data
      */
     class Wcal_Personal_Data_Export {
-    
+
         /**
          * Construct
          * @since 7.8
-         */ 
+         */
         public function __construct() {
             // Hook into the WP export process
             add_filter( 'wp_privacy_personal_data_exporters', array( &$this, 'wcal_exporter_array' ), 6 );
         }
-    
+
         /**
          * Add our export and it's callback function
-         * 
+         *
          * @param array $exporters - Any exportes that need to be added by 3rd party plugins
          * @param array $exporters - Exportes list containing our plugin details
-         * 
+         *
          * @since 4.9
-         */ 
+         */
         public static function wcal_exporter_array( $exporters = array() ) {
-            
+
             $exporter_list = array();
             // Add our export and it's callback function
-            $exporter_list[ 'wcal_carts' ] = array( 
+            $exporter_list[ 'wcal_carts' ] = array(
                 'exporter_friendly_name' => __( 'Abandoned & Recovered Carts', 'woocommerce-abandoned-cart' ),
                 'callback'               => array( 'Wcal_Personal_Data_Export', 'wcal_data_exporter' )
             );
-             
+
             $exporters = array_merge( $exporters, $exporter_list );
 
             return $exporters;
-            
+
         }
-        
+
         /**
-         * Returns data to be displayed for exporting the 
+         * Returns data to be displayed for exporting the
          * cart details
-         * 
+         *
          * @param string $email_address - EMail Address for which personal data is being exported
          * @param integer $page - The Export page number
          * @return array $data_to_export - Data to be exported
-         * 
+         *
          * @hook wp_privacy_personal_data_exporters
          * @global $wpdb
          * @since  4.9
          */
         static function wcal_data_exporter( $email_address, $page ) {
-            
+
             global $wpdb;
-            
+
             $done                   = false;
             $page                   = (int) $page;
             $user                   = get_user_by( 'email', $email_address ); // Check if user has an ID in the DB to load stored personal data.
             $data_to_export         = array();
             $blank_cart_info        = '{"cart":[]}';
             $blank_cart_info_guest  = '[]';
-            $blank_cart             = '""';   
-            
+            $blank_cart             = '""';
+
             $user_id = $user ? (int) $user->ID : 0;
-            
+
             if ( $user_id > 0 ) { // registered user
-                
+
                 $cart_query = "SELECT id FROM `" . $wpdb->prefix . 'ac_abandoned_cart_history_lite' . "`
                                WHERE user_id = %d AND
                                user_type = 'REGISTERED' AND abandoned_cart_info NOT LIKE '%$blank_cart_info%' AND abandoned_cart_info NOT LIKE '$blank_cart'";
-                
+
                 $cart_ids = $wpdb->get_results( $wpdb->prepare( $cart_query, $user_id ) );
             } else { // guest carts
                 $guest_query = "SELECT id FROM `" . $wpdb->prefix . 'ac_guest_abandoned_cart_history_lite' . "`
                                 WHERE email_id = %s";
-                
+
                 $guest_user_ids = $wpdb->get_results( $wpdb->prepare( $guest_query, $email_address ) );
-                
-                if ( 0 == count( $guest_user_ids ) ) 
+
+                if ( 0 == count( $guest_user_ids ) )
                     return array(
                        'data' => array(),
                        'done' => true,
                     );
-                
+
                 $cart_ids = array();
-                
+
                 foreach ( $guest_user_ids as $ids ) {
                     // get the cart data
                     $cart_query = "SELECT id, abandoned_cart_info AS cart_info FROM `" . $wpdb->prefix . 'ac_abandoned_cart_history_lite' . "`
                                    WHERE user_id = %d AND
                                    user_type = 'GUEST'";
-                    
+
                     $cart_data = $wpdb->get_results( $wpdb->prepare( $cart_query, $ids->id ) );
-                    
+
                     $cart_ids = array_merge( $cart_ids, $cart_data );
                 }
             }
-            
+
             if ( 0 < count( $cart_ids ) ) {
-                
+
                 $cart_chunks = array_chunk( $cart_ids, 10, true );
-                
+
                 $cart_export = isset( $cart_chunks[ $page - 1 ] ) ? $cart_chunks[ $page - 1 ] : array();
                 if ( count( $cart_export ) > 0 ) {
-                    
+
                     foreach ( $cart_export as $abandoned_ids ) {
-                    
+
                         $cart_id = $abandoned_ids->id;
                         if ( count( $abandoned_ids->id ) > 0 ) {
                             $data_to_export[] = array(
@@ -133,17 +133,17 @@ if ( ! class_exists('Wcal_Personal_Data_Export' ) ) {
             } else {
                 $done = true;
             }
-            
+
             return array(
                 'data' => $data_to_export,
                 'done' => $done,
             );
-    
+
         }
-        
+
         /**
          * Returns the personal data for each abandoned cart
-         * 
+         *
          * @param integer $abandoned_id - Abandoned Cart ID
          * @return array $personal_data - Personal data to be displayed
          * @global $wpdb
@@ -151,9 +151,9 @@ if ( ! class_exists('Wcal_Personal_Data_Export' ) ) {
          */
         static function get_cart_data( $abandoned_id ) {
             $personal_data = array();
-            
+
             global $wpdb;
-            
+
             $cart_query   = "SELECT * FROM `" . $wpdb->prefix . 'ac_abandoned_cart_history_lite' . "`
                              WHERE id = %d";
             $cart_details = $wpdb->get_results( $wpdb->prepare( $cart_query, $abandoned_id ) );
@@ -173,7 +173,7 @@ if ( ! class_exists('Wcal_Personal_Data_Export' ) ) {
                 'formatted_billing_address'  => __( 'Billing Address', 'woocommerce-abandoned-cart' ),
                 'billing_email'              => __( 'Email Address', 'woocommerce-abandoned-cart' ),
             ), $abandoned_id );
-           
+
            } else {
             $cart_details_to_export = apply_filters( 'wcal_personal_export_cart_details_prop', array(
                 'cart_id'                    => __( 'Abandoned Cart ID', 'woocommerce-abandoned-cart' ),
@@ -184,21 +184,21 @@ if ( ! class_exists('Wcal_Personal_Data_Export' ) ) {
                 'formatted_billing_address'  => __( 'Billing Address', 'woocommerce-abandoned-cart' ),
                 'billing_email'              => __( 'Email Address', 'woocommerce-abandoned-cart' ),
             ), $abandoned_id );
-            
-           }         
-            
+
+           }
+
             $cart_data = json_decode( stripslashes( $cart_details->abandoned_cart_info ) );
             $cart_info = $cart_data->cart;
-            
+
             if ( count( $cart_info ) > 0 ) {
                 $cart_details_formatted = self::wcal_get_cart_details_export( $cart_info );
             }
-            
+
             if ( 'GUEST' == $user_type ) {
                 $guest_details = self::wcal_get_guest_personal_info( $user_id );
             }
             foreach ( $cart_details_to_export as $prop => $name ) {
-                
+
                 switch ( $prop ) {
                     case 'cart_id':
                         $value = $cart_details->id;
@@ -207,9 +207,9 @@ if ( ! class_exists('Wcal_Personal_Data_Export' ) ) {
                         $value = date( 'Y-m-d H:i:s', $cart_details->abandoned_cart_time );
                         break;
                     case 'cart_status':
-                        
+
                         $cart_ignored = $cart_details->cart_ignored;
-                        
+
                         switch( $cart_ignored ) {
                             case '0':
                                 $value =  $cart_details->recovered_cart > 0  ? __( "Cart Recovered - Order #", 'woocommerce-abandoned-cart' ) . $cart_details->recovered_cart : __( 'Abandoned', 'woocommerce-abandoned-cart' );
@@ -218,16 +218,16 @@ if ( ! class_exists('Wcal_Personal_Data_Export' ) ) {
                                 $value = $cart_details->recovered_cart > 0  ? __( "Cart Recovered - Order #", 'woocommerce-abandoned-cart' ) . $cart_details->recovered_cart : __( 'Abandoned but new cart created', 'woocommerce-abandoned-cart' );
                                 break;
                             case '2':
-                                $value = __( 'Abandoned - Order Unpaid (Order #', 'woocommerce-abandoned-cart') . $cart_details->recovered_cart . ")";
+                                $value = __( 'Abandoned - Unpaid Order #', 'woocommerce-abandoned-cart') . $cart_details->recovered_cart;
                                 break;
                         }
                         break;
                     case 'total':
                         $total = 0;
-                        
+
                         if ( count( $cart_info ) > 0 ) {
                             foreach ( $cart_info as $k => $v ) {
-                        
+
                                 $total += $cart_details_formatted[$k][ 'item_total' ];
                             }
                         }
@@ -235,31 +235,31 @@ if ( ! class_exists('Wcal_Personal_Data_Export' ) ) {
                         break;
                     case 'items':
                         $value = '';
-                        
+
                         if ( count( $cart_info ) > 0 ) {
                             foreach ( $cart_info as $k => $v ) {
-                        
+
                                 $product_name = $cart_details_formatted[$k][ 'product_name' ];
                                 $qty = $cart_details_formatted[$k][ 'qty' ];
-                        
+
                                 $value .= ( $value == '' ) ? "$product_name x $qty" : ", $product_name x $qty";
                             }
                         }
                         break;
                     case 'formatted_billing_address':
-                        
+
                         if ( $user_type == 'REGISTERED' ) { // registered user
-                            
+
                             $billing = wcal_common::wcal_get_billing_details( $user_id );
                             $value = get_user_meta( $user_id, 'billing_first_name', true ); // First Name
-                            $value .= ' ' . get_user_meta( $user_id, 'billing_last_name', true ); // Last Name 
+                            $value .= ' ' . get_user_meta( $user_id, 'billing_last_name', true ); // Last Name
                             if ( count( $billing ) > 0 ) {
                                 foreach ( $billing as $details ) {
                                     if ( '' != $details ) {
                                         $value .= ",$details ";
-                                    } 
+                                    }
                                 }
-                                
+
                             }
                         } elseif ( 'GUEST' == $user_type ) {
                             if ( count( $guest_details ) > 0 ) {
@@ -268,13 +268,13 @@ if ( ! class_exists('Wcal_Personal_Data_Export' ) ) {
                             }
                         }
                         break;
-                    
+
                     case 'billing_email':
                         if ( 'REGISTERED' == $user_type ) { // registered user
                             $value = get_user_meta( $user_id, $prop, true );
                         } else if ( 'GUEST' == $user_type ) {
                             if ( count( $guest_details ) > 0 ) {
-                                $value = $guest_details->$prop; 
+                                $value = $guest_details->$prop;
                             }
                         }
                         break;
@@ -282,24 +282,24 @@ if ( ! class_exists('Wcal_Personal_Data_Export' ) ) {
                         $value = ( isset( $cart_details->$prop ) ) ? $cart_details->$prop : '';
                         break;
                 }
-                
+
                 $value = apply_filters( 'wcal_personal_export_cart_details_prop_value', $value, $prop, $cart_details );
-                
-                $personal_data[] = array( 
+
+                $personal_data[] = array(
                     'name'  => $name,
                     'value' => $value,
                 );
-            
+
             }
             $personal_data = apply_filters( 'wcal_personal_data_cart_details_export', $personal_data, $cart_details );
-            
+
             return $personal_data;
         }
-        
+
         /**
          * Returns the personal data from the plugin guest cart table
          * for guest abandoned carts
-         * 
+         *
          * @param integer $user_id - User ID
          * @return array $guest_details - Guest personal details
          * @global $wpdb
@@ -308,70 +308,70 @@ if ( ! class_exists('Wcal_Personal_Data_Export' ) ) {
         static function wcal_get_guest_personal_info( $user_id ) {
             global $wpdb;
             $guest_details = array();
-            
+
             $guest_query   = "SELECT billing_first_name, billing_last_name, email_id AS billing_email, phone AS billing_phone FROM `" . $wpdb->prefix . 'ac_guest_abandoned_cart_history_lite' . "`
                               WHERE id = %d";
-            
+
             $guest_details = $wpdb->get_results( $wpdb->prepare( $guest_query, $user_id ) );
-            
+
             if ( is_array( $guest_details ) && count( $guest_details ) > 0 ) {
                 $guest_details = $guest_details[0];
             }
-            
+
             return $guest_details;
         }
-        
+
         /**
          * Returns the Cart Details such as quantity, product name
          * etc.
-         * 
+         *
          * @param object $cart_info - Abandoned Cart Information
          * @return array $cart_details - Array containing product, qty & total for each item
          * @since 4.9
          */
         static function wcal_get_cart_details_export( $cart_info ) {
-            
+
             $cart_details = array();
-             
+
             if ( count( $cart_info ) > 0 ) {
-                    
+
                 $cart_total = 0;
                 foreach ( $cart_info as $k => $item_detail ) {
-                        
+
                     // Qty
                     $qty = $item_detail->quantity;
-                     
+
                     //Product Name
                     $product_id     = $item_detail->product_id;
                     $prod_obj       = wc_get_product( $product_id );
                     $product_name   = $prod_obj->get_name();
-                     
+
                     // Variation Name
                     if ( isset( $item_detail->variation_id ) && $item_detail->variation_id > 0 ) {
                         $variation_id   = $item_detail->variation_id;
                         $variation      = wc_get_product( $variation_id );
                         $variation_name = $variation->get_name();
-                         
+
                         $product_name = $variation_name;
                     }
-                    
+
                     // Total
                     $item_total = $item_detail->line_total;
                     if ( $item_detail->line_subtotal_tax > 0 ) {
                         $item_total += $item_detail->line_subtotal_tax;
-                    } 
-                     
+                    }
+
                     // Populate the array
                     $cart_details[ $k ][ 'qty' ]          = $qty;
                     $cart_details[ $k ][ 'product_name' ] = $product_name;
                     $cart_details[ $k ][ 'item_total' ]   = $item_total;
-                     
+
                     $cart_total += $item_total;
                 }
-                    
+
                 $cart_details[ 'total' ] = $cart_total;
             }
-            
+
             return $cart_details;
         }
     } // end of class

--- a/woocommerce-abandoned-cart/includes/admin/wcap_add_cart_popup_modal.php
+++ b/woocommerce-abandoned-cart/includes/admin/wcap_add_cart_popup_modal.php
@@ -1,398 +1,796 @@
-<?php
-/**
- * It will fetch the Add to cart data, generate and populate data in the modal.
- * @author  Tyche Softwares
- * @package Abandoned-Cart-Pro-for-WooCommerce/Admin/Settings
- * @since 6.0
- */
-if ( ! defined( 'ABSPATH' ) ) {
-    exit; // Exit if accessed directly.
-}
-if ( ! class_exists( 'Wcap_Add_Cart_Popup_Modal' ) ) {
-    
-    /**
- 	 * It will fetch the Add to cart data, generate and populate data in the modal.
- 	 * @since 6.0
- 	 */
-    class Wcap_Add_Cart_Popup_Modal {
-
-    	/**
-    	 * This function will add the add to cart popup medal's settings.
-    	 * @since 6.0
-    	 */
-        public static function wcap_add_to_cart_popup_settings() {
-    		$wcap_atc_enabled        = get_option( 'wcap_atc_enable_modal' );
-    		$wcap_disabled_field     = '';
-    		if ( 'off' == $wcap_atc_enabled ) {
-    			$wcap_disabled_field = 'disabled="disabled"';
-    		} 
-    		?>
-			<div id = "wcap_popup_main_div" class = "wcap_popup_main_div ">
-    			<table id = "wcap_popup_main_table" class = "wcap_popup_main_table test_borders">
-    				<tr id = "wcap_popup_main_table_tr" class = "wcap_popup_main_table_tr test_borders">
-    					<td id = "wcap_popup_main_table_td_settings" class = "wcap_popup_main_table_td_settings test_borders">    						
-    						<?php Wcap_Add_Cart_Popup_Modal::wcap_enable_modal_section( $wcap_disabled_field ); ?>
-    						<?php self::wcap_custom_pages_section( $wcap_disabled_field ); ?>
-    						<div class = "wcap_atc_all_fields_container" >
-	    						<?php Wcap_Add_Cart_Popup_Modal::wcap_add_heading_section( $wcap_disabled_field ); ?>
-	    						<?php Wcap_Add_Cart_Popup_Modal::wcap_add_text_section( $wcap_disabled_field ); ?>
-	    						<?php Wcap_Add_Cart_Popup_Modal::wcap_email_placeholder_section( $wcap_disabled_field ); ?>
-	    						<?php Wcap_Add_Cart_Popup_Modal::wcap_button_section( $wcap_disabled_field ); ?>
-	    						<?php Wcap_Add_Cart_Popup_Modal::wcap_mandatory_modal_section( $wcap_disabled_field ); ?>
-	    						<?php Wcap_Add_Cart_Popup_Modal::wcap_non_mandatory_modal_section_field( $wcap_disabled_field ); ?>
-    						</div>
-    					</td>
-    					<td id = "wcap_popup_main_table_td_preview" class = "wcap_popup_main_table_td_preview test_borders">
-    						<div class = "wcap_atc_all_fields_container" >
-    							<?php Wcap_Add_Cart_Popup_Modal::wcap_add_to_cart_popup_modal_preview( $wcap_disabled_field ); ?>
-    						</div>
-    					</td>
-					</tr>
-    				<tr>
-    					<td>
-    						<div class = "wcap_atc_all_fields_container" >
-    							<p class = "submit">
-    								<input type = "submit" name = "submit" id = "submit" class = "button button-primary" value = "Save Changes" <?php echo $wcap_disabled_field; ?> >
-    								<input type = "submit" name = "submit" id = "submit" class = "wcap_reset_button button button-primary" value = "Reset to default configuration" <?php echo $wcap_disabled_field; ?> >
-    							</p>
-    						</div>
-    					</td>
-					</tr>
-    			</table>
-			</div>
-    		<?php
-    	}
-
-    	/**
-    	 * It will add the "Enable Add to cart popup modal" setting on the add to cart modal settings page.
-    	 * @param string $wcap_disabled_field It will indicate if field need to be disabled or not.
-    	 * @since 6.0
-    	 */
-		public static function wcap_enable_modal_section( $wcap_disabled_field ){
-    		?>
-    			<table class = "wcap_enable_atc wcap_atc_between_fields_space" id = "wcap_enable_atc" >
-    				<th id = "wcap_button_section_table_heading" class = "wcap_button_section_table_heading"> Enable Add to cart popup modal </th>
-    				<tr>
-    					<td>
-    					   <?php 
-    					   $wcap_atc_enabled = get_option('wcap_atc_enable_modal');
-    				       $active_text      = __( $wcap_atc_enabled, 'woocommerce-abandoned-cart' ); 
-    				       ?>
-    				       <button type = "button" class = "wcap-enable-atc-modal wcap-toggle-atc-modal-enable-status" wcap-atc-switch-modal-enable = 'off' ?> readonly>
-    					   <?php echo $active_text; ?>  
-    					   </button>
-    					</td>
-					</tr>
-				</table>
-    		<?php	
-    	}
-
-    	/**
-    	 * Adds a multi select searchable dropdown from where
-    	 * the admin can select custom pages on which the
-    	 * Add to Cart Popup modal should be displayed. 
-    	 * 
-    	 * @param string $wcap_disabled_field It will indicate if field need to be disabled or not.
-    	 * @since 7.10.0
-    	 */
-    	public static function wcap_custom_pages_section( $wcap_disabled_field ) {
-             global $woocommerce;
-            $post_title_array = array();
-    	    ?>
-    	    <table class = "wcap_custom_pages wcap_atc_between_fields_space" id = "wcap_custom_pages" >
-                <tr>
-            	    <th id="wcap_button_section_table_heading" class="wcap_button_section_table_heading"> <?php _e( 'Custom pages to display the pop-up modal on', 'woocommerce-abandoned-cart' );?> </th>
-                </tr>
-        	    <tr>
-            	    <td>
-                	    <?php
-                        $custom_pages = get_option('wcap_custom_pages_list');
-                        ?>
-                        <?php if ( $woocommerce->version >= '3.0' ) { ?>
-                            <select style="width:80%" multiple="multiple" class="wcap_page_select wc-product-search" name="wcap_page_select[]" data-placeholder='<?php esc_attr__( 'Search for a Page&hellip;', 'woocommerce-abandoned-cart' )?>' data-action='wcap_json_find_pages' disabled>
-
-                                <?php 
-                                   if( is_array( $custom_pages ) && count( $custom_pages ) > 0 ) {
-                                       foreach( $custom_pages as $page_ids ) {
-                                           $post_id = $page_ids;
-                                           $post_title = get_the_title( $post_id );
-                                           
-                                           printf( "<option value='%s' selected>%s</option>\n", $post_id, $post_title );
-                                       }
-                                   }
-                                ?> 
-                            </select> 
-                        <?php } else { 
-                            if( is_array( $post_title_array ) && is_array( $custom_pages ) && count( $custom_pages ) > 0 ) {
-                                       foreach( $custom_pages as $page_ids ) {
-                                           $post_id = $page_ids;
-                                           $post_title = get_the_title( $post_id );
-                                           $post_title_array[$post_title] = $post_title;
-                                          
-                                       }
-                                   }
-                            ?>
-                        
-                        <input type="hidden" style="width:80%" id = "wcap_page_select" class="wc-product-search" name="wcap_page_select[]" data-placeholder='<?php esc_attr_e( 'Search for a Page&hellip;', 'woocommerce-abandoned-cart' )?>' data-multiple="true" data-action='wcap_json_find_pages' data-selected=" <?php echo esc_attr( json_encode( $post_title_array ) ); ?>" value="<?php echo implode( ',', array_keys( $post_title_array ) ); ?>" readonly/>
-                            
-                        <?php } ?>
-               
-                        <?php $toolTip = __( 'Please add any custom pages (not created by WooCommerce) where you wish to display the Add to cart Pop-up Modal.', 'woocommerce-abandoned-cart' ); ?>
-                        <?php echo wc_help_tip( $toolTip ); ?>
-                    </td>
-                </tr>
-                <tr>
-                    <td colspan="2" style="text-align: justify;">
-                        <?php _e( "<b>Note:</b> Please ensure that the Add to Cart button links on these pages are added with the correct classes and attributes to ensure the plugin can capture the cart data correctly. For further guidance, please check the documentation.", 'woocommerce-abandoned-cart' );?>
-                    </td>
-                </tr>
-			</table>
-    		<?php 
-    	}
-    	/**
-    	 * It will Save the setting on the add to cart modal settings page.
-    	 * @since 6.0
-    	 */
-        public static function wcap_add_to_cart_popup_save_settings() {
-			if ( $_POST ['wcap_heading_section_text_email'] ) {
-				update_option ( 'wcap_heading_section_text_email', $_POST ['wcap_heading_section_text_email'] );
-			}			
-			if ( $_POST ['wcap_popup_heading_color_picker'] ) {
-				update_option ( 'wcap_popup_heading_color_picker', $_POST ['wcap_popup_heading_color_picker'] );
-			}			
-			if ( $_POST ['wcap_text_section_text'] ) {
-				update_option ( 'wcap_text_section_text', $_POST ['wcap_text_section_text'] );
-			}			
-			if ( $_POST ['wcap_popup_text_color_picker'] ) {
-				update_option ( 'wcap_popup_text_color_picker', $_POST ['wcap_popup_text_color_picker'] );
-			}			
-			if ( $_POST ['wcap_email_placeholder_section_input_text'] ) {
-				update_option ( 'wcap_email_placeholder_section_input_text', $_POST ['wcap_email_placeholder_section_input_text'] );
-			}			
-			if ( $_POST ['wcap_button_section_input_text'] ) {
-				update_option ( 'wcap_button_section_input_text', $_POST ['wcap_button_section_input_text'] );
-			}
-			if ( $_POST ['wcap_button_color_picker'] ) {
-				update_option ( 'wcap_button_color_picker', $_POST ['wcap_button_color_picker'] );
-			}
-			if ( isset( $_POST ['wcap_button_text_color_picker'] ) ){
-				update_option ( 'wcap_button_text_color_picker', $_POST ['wcap_button_text_color_picker'] );
-			}
-			if ( isset( $_POST ['wcap_non_mandatory_modal_section_fields_input_text'] ) ) {
-				update_option( 'wcap_non_mandatory_text', $_POST ['wcap_non_mandatory_modal_section_fields_input_text'] );
-			}
-			
-			$custom_pages = isset( $_POST[ 'wcap_page_select' ] ) ? $_POST[ 'wcap_page_select' ] : array();
-		    update_option( 'wcap_custom_pages_list', $custom_pages );
-			
-		}
-
-		/**
-    	 * It will add the setting for Heading section on the add to cart modal settings page.
-    	 * @param string $wcap_disabled_field It will indicate if field need to be disabled or not.
-    	 * @since 6.0
-    	 */
-        public static function wcap_add_heading_section( $wcap_disabled_field ) {	
-    	    ?>
-            <div id = "wcap_heading_section_div" class = "wcap_heading_section_div wcap_atc_between_fields_space">
-                <table id = "wcap_heading_section_table" class = "wcap_heading_section_table">
-                    <th id = "wcap_heading_section_table_heading" class ="wcap_heading_section_table_heading"> Modal Heading </th>
-                    <tr id = "wcap_heading_section_tr" class = "wcap_heading_section_tr" >
-        				<td id = "wcap_heading_section_text_field" class = "wcap_heading_section_text_field test_borders">
-        					<input id = "wcap_heading_section_text_email" v-model = "wcap_heading_section_text_email"  name = "wcap_heading_section_text_email"class = "wcap_heading_section_text_email"
-        					<?php echo $wcap_disabled_field; ?> readonly value="<?php _e( 'Please enter your email address', 'woocommerce-abandoned-cart' ); ?>">
-        				</td>            				
-        				<td id = "wcap_heading_section_text_field_color" class = "wcap_heading_section_text_field_color test_borders">
-        					<?php $wcap_popup_heading_color_picker = get_option( 'wcap_popup_heading_color_picker' ); ?>
-        					<span class = "colorpickpreview" style = "background:<?php echo $wcap_popup_heading_color_picker; ?>"></span>
-        					<input class = "wcap_popup_heading_color_picker colorpick" name = "wcap_popup_heading_color_picker" value = "#737f97" v-model = "wcap_popup_heading_color" v-on:input = "wcap_atc_popup_heading.color = $event.target.value"
-					           <?php echo $wcap_disabled_field; ?> readonly >
-        				</td>
-    			     </tr>
-        		</table>
-    		</div>
-    		<?php
-    	}
-
-    	/**
-    	 * It will add the setting for Text displayed below heading section on the add to cart modal settings page.
-    	 * @param string $wcap_disabled_field It will indicate if field need to be disabled or not.
-    	 * @since 6.0
-    	 */
-    	public static function wcap_add_text_section( $wcap_disabled_field ) {
-    		?>
-            <div id = "wcap_text_section_div" class = "wcap_text_section_div wcap_atc_between_fields_space">
-                <table id = "wcap_text_section_table" class = "wcap_text_section_table">
-                    <th id = "wcap_text_section_table_heading" class = "wcap_text_section_table_heading"> Modal Text </th>
-                	<tr id = "wcap_text_section_tr" class = "wcap_text_section_tr" >
-                		<td id = "wcap_text_section_text_field" class = "wcap_text_section_text_field test_borders">
-                			<input id = "wcap_text_section_text" v-model = "wcap_text_section_text_field" class="wcap_text_section_input_text" name = "wcap_text_section_text"
-                			<?php echo $wcap_disabled_field; ?> readonly value="<?php _e( 'To add this item to your cart, please enter your email address.','woocommerce-abandoned-cart' ); ?>">
-                		</td>                    		
-                		<td id = "wcap_text_section_field_color" class = "wcap_text_section_field_color test_borders">
-                			<?php $wcap_atc_popup_text_color = get_option( 'wcap_popup_text_color_picker' ); ?>
-                			<span class = "colorpickpreview" style = "background:<?php echo $wcap_atc_popup_text_color; ?>"></span>
-                			<input class = "wcap_popup_text_color_picker colorpick" name = "wcap_popup_text_color_picker" value = "#bbc9d2" v-model = "wcap_popup_text_color" v-on:input = "wcap_atc_popup_text.color = $event.target.value"
-                			<?php echo $wcap_disabled_field; ?> readonly>
-                		</td>
-                	</tr>
-                </table>
-            </div>
-    		<?php
-		}
-
-		/**
-    	 * It will add the setting for email placeholder on the add to cart modal settings page.
-    	 * @param string $wcap_disabled_field It will indicate if field need to be disabled or not.
-    	 * @since 6.0
-    	 */
-    	public static function wcap_email_placeholder_section( $wcap_disabled_field ) {
-			?>
-    		<div id = "wcap_email_placeholder_section_div" class = "wcap_email_placeholder_section_div wcap_atc_between_fields_space">
-	    		<table id = "wcap_email_placeholder_section_table" class = "wcap_email_placeholder_section_table">
-	    		<th id = "wcap_email_placeholder_section_table_heading" class = "wcap_email_placeholder_section_table_heading"> Email placeholder </th>
-	    			<tr id = "wcap_email_placeholder_section_tr" class = "wcap_email_placeholder_section_tr" >
-	    				<td id = "wcap_email_placeholder_section_text_field" class = "wcap_email_placeholder_section_text_field test_borders">
-	    					<input id = "wcap_email_placeholder_section_input_text" v-model = "wcap_email_placeholder_section_input_text" class="wcap_email_placeholder_section_input_text" name = "wcap_email_placeholder_section_input_text" 
-	    					<?php echo $wcap_disabled_field; ?> readonly value="<?php _e('Email address', 'woocommerce-abandoned-cart' ); ?>">
-	    				</td>
-	    			</tr>
-	    		</table>
-    		</div>
-    		<?php
-    	}
-
-    	/**
-    	 * It will add the setting for Add to cart button on the add to cart modal settings page.
-    	 * @param string $wcap_disabled_field It will indicate if field need to be disabled or not.
-    	 * @since 6.0
-    	 */
-    	public static function wcap_button_section( $wcap_disabled_field ) {
-    		?>
-    		<div id = "wcap_button_section_div" class = "wcap_button_section_div wcap_atc_between_fields_space">
-	    		<table id = "wcap_button_section_table" class = "wcap_button_section_table">
-	    		<th id = "wcap_button_section_table_heading" class="wcap_button_section_table_heading"> Add to cart button text </th>
-	    			<tr>
-	    				<td id = "wcap_button_section_text_field" class = "wcap_button_section_text_field test_borders">
-	    					<input id = "wcap_button_section_input_text" v-model = "wcap_button_section_input_text" class="wcap_button_section_input_text" name = "wcap_button_section_input_text"
-	    					<?php echo $wcap_disabled_field ; ?> readonly value="<?php _e( 'Add to Cart', 'woocommerce-abandoned-cart' ); ?>">
-	    				</td>
-	    			</tr>
-	    			<tr id = "wcap_button_color_section_tr" class = "wcap_button_color_section_tr">
-	    				<td id = "wcap_button_color_section_text_field" class = "wcap_button_color_section_text_field test_borders">
-	    					<?php $wcap_atc_button_bg_color = get_option( 'wcap_button_color_picker' ); ?>
-	    					<span class = "colorpickpreview" style = "background:<?php echo $wcap_atc_button_bg_color; ?>"></span>
-	    					<input id = "wcap_button_color_picker" value = "#0085ba" v-model ="wcap_button_bg_color" v-on:input="wcap_atc_button.backgroundColor = $event.target.value" class="wcap_button_color_picker colorpick" name = "wcap_button_color_picker"
-							<?php echo $wcap_disabled_field; ?> readonly >
-	    				</td>
-	    				<td id = "wcap_button_text_color_section_text_field" class = "wcap_button_text_color_section_text_field test_borders">
-	    					<?php $wcap_button_text_color_picker = get_option('wcap_button_text_color_picker'); ?>
-	    					<span class = "colorpickpreview" style = "background:<?php echo $wcap_button_text_color_picker; ?>"></span>
-	    					<input id = "wcap_button_text_color_picker" value = "#ffffff" v-model = "wcap_button_text_color" v-on:input = "wcap_atc_button.color = $event.target.value" class="wcap_button_text_color_picker colorpick" name = "wcap_button_text_color_picker" 
-	    					<?php echo $wcap_disabled_field; ?> readonly>
-	    				</td>
-					</tr>
-	    		</table>
-    		</div>
-    		<?php
-    	}
-		
-		/**
-    	 * It will add the setting for Email address mandatory field on the add to cart modal settings page.
-    	 * @param string $wcap_disabled_field It will indicate if field need to be disabled or not.
-    	 * @since 6.0
-    	 */
-		public static function wcap_mandatory_modal_section( $wcap_disabled_field ) {
-			?>
-			<table class = "wcap_atc_between_fields_space">
-				<th id = "wcap_button_section_table_heading" class = "wcap_button_section_table_heading"> Email address is mandatory ? </th>
-				<tr>
-					<td>
-					   <?php 
-					   $wcap_atc_email_mandatory = get_option( 'wcap_atc_mandatory_email' );
-				       $active_text   			 = __( $wcap_atc_email_mandatory, 'woocommerce-abandoned-cart' );
-				       ?>
-				       <button type = "button" class = "wcap-switch-atc-modal-mandatory wcap-toggle-atc-modal-mandatory" wcap-atc-switch-modal-mandatory = <?php echo $wcap_atc_email_mandatory; ?> 
-				       <?php echo $wcap_disabled_field; ?> readonly >
-					   <?php echo $active_text; ?> </button>
-					</td>
-				</tr>
-			</table>
-    		<?php
-    	}
-
-    	/**
-    	 * It will add the setting for Email address non mandatory field on the add to cart modal settings page.
-    	 * @param string $wcap_disabled_field It will indicate if field need to be disabled or not.
-    	 * @since 6.0
-    	 */
-    	public static function wcap_non_mandatory_modal_section_field( $wcap_disabled_field ) {
-    		$wcap_get_mandatory_field      = get_option( 'wcap_atc_mandatory_email' );
-    		$wcap_disabled_email_field     = '';
-    		if ( 'on' == $wcap_get_mandatory_field ) {
-    			$wcap_disabled_email_field = 'disabled="disabled"';
-    		}
-			?>
-    		<div id = "wcap_non_mandatory_modal_section_fields_div" class = "wcap_non_mandatory_modal_section_fields_div wcap_atc_between_fields_space">
-	    		<table id = "wcap_non_mandatory_modal_section_fields_div_table" class = "wcap_non_mandatory_modal_section_fields_div_table">
-    	    		<th id = "wcap_non_mandatory_modal_section_fields_table_heading" 
-    	    		class="wcap_non_mandatory_modal_section_fields_table_heading"> Not mandatory text </th>
-	    			<tr id = "wcap_non_mandatory_modal_section_fields_tr" class = "wcap_non_mandatory_modal_section_fields_tr" >
-	    				<td id = "wcap_non_mandatory_modal_section_fields_text_field" class = "wcap_non_mandatory_modal_section_fields_text_field test_borders">
-	    					<input id = "wcap_non_mandatory_modal_section_fields_input_text" v-model = "wcap_non_mandatory_modal_input_text" class = "wcap_non_mandatory_modal_section_fields_input_text" name = "wcap_non_mandatory_modal_section_fields_input_text" readonly value="<?php _e( 'No Thanks', 'woocommerce-abandoned-cart' ); ?>"
-	    					<?php echo $wcap_disabled_field; 
-	    						  echo $wcap_disabled_email_field;
-	    					?> >
-	    				</td>
-	    			</tr>
-	    		</table>
-    		</div>
-    		<?php
-    	}
-
-    	/**
-    	 * It will will show th preview of the Add To cart Popup modal with the changes made on any of the settings for it.
-    	 * @param string $wcap_disabled_field It will indicate if field need to be disabled or not.
-    	 * @since 6.0
-    	 */
-    	public static function wcap_add_to_cart_popup_modal_preview( $wcap_disabled_field ) {
-    		
-    		?>
-    		<div class = "wcap_container">
-				<div class = "wcap_popup_wrapper">
-				    <div class = "wcap_popup_content">
-				        <div class = "wcap_popup_heading_container">
-				            <div class = "wcap_popup_icon_container" >
-				                <span class = "wcap_popup_icon"  >
-				                    <span class = "wcap_popup_plus_sign" v-bind:style = "wcap_atc_button">
-				                    </span>
-				                </span>
-				            </div>
-				            <div class = "wcap_popup_text_container">
-				                <h2 class = "wcap_popup_heading" v-bind:style = "wcap_atc_popup_heading" ><?php _e( 'Please enter your email address.', 'woocommerce-abandoned-cart' ); ?></h2>
-				                <div class = "wcap_popup_text" v-bind:style = "wcap_atc_popup_text" ><?php _e( 'To add this item to your cart, please enter your email address.', 'woocommerce-abandoned-cart' ); ?></div>
-				            </div>
-				        </div>
-				        <div class = "wcap_popup_form">
-				            <form action = "" name = "wcap_modal_form">
-				                <div class = "wcap_popup_input_field_container"  >
-				                    <input class = "wcap_popup_input" type = "text" value = "" name = "email" placeholder ="<?php _e( 'Email address', 'woocommerce-abandoned-cart' ); ?>"
-				                    <?php echo $wcap_disabled_field; ?> readonly >
-				                </div>
-				                <button class = "wcap_popup_button" v-bind:style = "wcap_atc_button"
-				                <?php echo $wcap_disabled_field ; ?> ><?php _e( 'Add to Cart', 'woocommerce-abandoned-cart' ); ?></button>
-				                <br>
-				                <br>
-				                <div id = "wcap_non_mandatory_text_wrapper" class = "wcap_non_mandatory_text_wrapper">
-				                    <a class = "wcap_popup_non_mandatory_button" href = "" > <?php _e( 'No Thanks', 'woocommerce-abandoned-cart' ); ?></a>
-				                </div>
-				            </form>
-				        </div>
-				        <div class = "wcap_popup_close" ></div>
-				    </div>
-				</div>
-			</div>
-    		<?php
-    	}
-	}
-}
+<?php
+
+/**
+
+ * It will fetch the Add to cart data, generate and populate data in the modal.
+
+ * @author  Tyche Softwares
+
+ * @package Abandoned-Cart-Pro-for-WooCommerce/Admin/Settings
+
+ * @since 6.0
+
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+
+    exit; // Exit if accessed directly.
+
+}
+
+if ( ! class_exists( 'Wcap_Add_Cart_Popup_Modal' ) ) {
+
+
+
+    /**
+
+ 	 * It will fetch the Add to cart data, generate and populate data in the modal.
+
+ 	 * @since 6.0
+
+ 	 */
+
+    class Wcap_Add_Cart_Popup_Modal {
+
+
+
+    	/**
+
+    	 * This function will add the add to cart popup medal's settings.
+
+    	 * @since 6.0
+
+    	 */
+
+        public static function wcap_add_to_cart_popup_settings() {
+
+    		$wcap_atc_enabled        = get_option( 'wcap_atc_enable_modal' );
+
+    		$wcap_disabled_field     = '';
+
+    		if ( 'off' == $wcap_atc_enabled ) {
+
+    			$wcap_disabled_field = 'disabled="disabled"';
+
+    		}
+
+    		?>
+
+			<div id = "wcap_popup_main_div" class = "wcap_popup_main_div ">
+
+    			<table id = "wcap_popup_main_table" class = "wcap_popup_main_table test_borders">
+
+    				<tr id = "wcap_popup_main_table_tr" class = "wcap_popup_main_table_tr test_borders">
+
+    					<td id = "wcap_popup_main_table_td_settings" class = "wcap_popup_main_table_td_settings test_borders">
+
+    						<?php Wcap_Add_Cart_Popup_Modal::wcap_enable_modal_section( $wcap_disabled_field ); ?>
+
+    						<?php self::wcap_custom_pages_section( $wcap_disabled_field ); ?>
+
+    						<div class = "wcap_atc_all_fields_container" >
+
+	    						<?php Wcap_Add_Cart_Popup_Modal::wcap_add_heading_section( $wcap_disabled_field ); ?>
+
+	    						<?php Wcap_Add_Cart_Popup_Modal::wcap_add_text_section( $wcap_disabled_field ); ?>
+
+	    						<?php Wcap_Add_Cart_Popup_Modal::wcap_email_placeholder_section( $wcap_disabled_field ); ?>
+
+	    						<?php Wcap_Add_Cart_Popup_Modal::wcap_button_section( $wcap_disabled_field ); ?>
+
+	    						<?php Wcap_Add_Cart_Popup_Modal::wcap_mandatory_modal_section( $wcap_disabled_field ); ?>
+
+	    						<?php Wcap_Add_Cart_Popup_Modal::wcap_non_mandatory_modal_section_field( $wcap_disabled_field ); ?>
+
+    						</div>
+
+    					</td>
+
+    					<td id = "wcap_popup_main_table_td_preview" class = "wcap_popup_main_table_td_preview test_borders">
+
+    						<div class = "wcap_atc_all_fields_container" >
+
+    							<?php Wcap_Add_Cart_Popup_Modal::wcap_add_to_cart_popup_modal_preview( $wcap_disabled_field ); ?>
+
+    						</div>
+
+    					</td>
+
+					</tr>
+
+    				<tr>
+
+    					<td>
+
+    						<div class = "wcap_atc_all_fields_container" >
+
+    							<p class = "submit">
+
+    								<input type = "submit" name = "submit" id = "submit" class = "button button-primary" value = "Save Changes" <?php echo $wcap_disabled_field; ?> >
+
+    								<input type = "submit" name = "submit" id = "submit" class = "wcap_reset_button button button-primary" value = "Reset to default configuration" <?php echo $wcap_disabled_field; ?> >
+
+    							</p>
+
+    						</div>
+
+    					</td>
+
+					</tr>
+
+    			</table>
+
+			</div>
+
+    		<?php
+
+    	}
+
+
+
+    	/**
+
+    	 * It will add the "Enable Add to cart popup modal" setting on the add to cart modal settings page.
+
+    	 * @param string $wcap_disabled_field It will indicate if field need to be disabled or not.
+
+    	 * @since 6.0
+
+    	 */
+
+		public static function wcap_enable_modal_section( $wcap_disabled_field ){
+
+    		?>
+
+    			<table class = "wcap_enable_atc wcap_atc_between_fields_space" id = "wcap_enable_atc" >
+
+    				<th id = "wcap_button_section_table_heading" class = "wcap_button_section_table_heading"> <?php _e( 'Enable Add to cart popup modal', 'woocommerce-abandoned-cart' ); ?> </th>
+
+    				<tr>
+
+    					<td>
+
+    					   <?php
+
+    					   $wcap_atc_enabled = get_option('wcap_atc_enable_modal');
+
+    				       $active_text      = $wcap_atc_enabled;
+
+    				       ?>
+
+    				       <button type = "button" class = "wcap-enable-atc-modal wcap-toggle-atc-modal-enable-status" wcap-atc-switch-modal-enable = 'off' ?> readonly>
+
+    					   <?php echo $active_text; ?>
+
+    					   </button>
+
+    					</td>
+
+					</tr>
+
+				</table>
+
+    		<?php
+
+    	}
+
+
+
+    	/**
+
+    	 * Adds a multi select searchable dropdown from where
+
+    	 * the admin can select custom pages on which the
+
+    	 * Add to Cart Popup modal should be displayed.
+
+    	 *
+
+    	 * @param string $wcap_disabled_field It will indicate if field need to be disabled or not.
+
+    	 * @since 7.10.0
+
+    	 */
+
+    	public static function wcap_custom_pages_section( $wcap_disabled_field ) {
+
+             global $woocommerce;
+
+            $post_title_array = array();
+
+    	    ?>
+
+    	    <table class = "wcap_custom_pages wcap_atc_between_fields_space" id = "wcap_custom_pages" >
+
+                <tr>
+
+            	    <th id="wcap_button_section_table_heading" class="wcap_button_section_table_heading"> <?php _e( 'Custom pages to display the pop-up modal on', 'woocommerce-abandoned-cart' );?> </th>
+
+                </tr>
+
+        	    <tr>
+
+            	    <td>
+
+                	    <?php
+
+                        $custom_pages = get_option('wcap_custom_pages_list');
+
+                        ?>
+
+                        <?php if ( $woocommerce->version >= '3.0' ) { ?>
+
+                            <select style="width:80%" multiple="multiple" class="wcap_page_select wc-product-search" name="wcap_page_select[]" data-placeholder='<?php esc_attr__( 'Search for a Page&hellip;', 'woocommerce-abandoned-cart' )?>' data-action='wcap_json_find_pages' disabled>
+
+
+
+                                <?php
+
+                                   if( is_array( $custom_pages ) && count( $custom_pages ) > 0 ) {
+
+                                       foreach( $custom_pages as $page_ids ) {
+
+                                           $post_id = $page_ids;
+
+                                           $post_title = get_the_title( $post_id );
+
+
+
+                                           printf( "<option value='%s' selected>%s</option>\n", $post_id, $post_title );
+
+                                       }
+
+                                   }
+
+                                ?>
+
+                            </select>
+
+                        <?php } else {
+
+                            if( is_array( $post_title_array ) && is_array( $custom_pages ) && count( $custom_pages ) > 0 ) {
+
+                                       foreach( $custom_pages as $page_ids ) {
+
+                                           $post_id = $page_ids;
+
+                                           $post_title = get_the_title( $post_id );
+
+                                           $post_title_array[$post_title] = $post_title;
+
+
+
+                                       }
+
+                                   }
+
+                            ?>
+
+
+
+                        <input type="hidden" style="width:80%" id = "wcap_page_select" class="wc-product-search" name="wcap_page_select[]" data-placeholder='<?php esc_attr_e( 'Search for a Page&hellip;', 'woocommerce-abandoned-cart' )?>' data-multiple="true" data-action='wcap_json_find_pages' data-selected=" <?php echo esc_attr( json_encode( $post_title_array ) ); ?>" value="<?php echo implode( ',', array_keys( $post_title_array ) ); ?>" readonly/>
+
+
+
+                        <?php } ?>
+
+
+
+                        <?php $toolTip = __( 'Please add any custom pages (not created by WooCommerce) where you wish to display the Add to cart Pop-up Modal.', 'woocommerce-abandoned-cart' ); ?>
+
+                        <?php echo wc_help_tip( $toolTip ); ?>
+
+                    </td>
+
+                </tr>
+
+                <tr>
+
+                    <td colspan="2" style="text-align: justify;">
+
+                        <?php _e( "<b>Note:</b> Please ensure that the Add to Cart button links on these pages are added with the correct classes and attributes to ensure the plugin can capture the cart data correctly. For further guidance, please check the documentation.", 'woocommerce-abandoned-cart' );?>
+
+                    </td>
+
+                </tr>
+
+			</table>
+
+    		<?php
+
+    	}
+
+    	/**
+
+    	 * It will Save the setting on the add to cart modal settings page.
+
+    	 * @since 6.0
+
+    	 */
+
+        public static function wcap_add_to_cart_popup_save_settings() {
+
+			if ( $_POST ['wcap_heading_section_text_email'] ) {
+
+				update_option ( 'wcap_heading_section_text_email', $_POST ['wcap_heading_section_text_email'] );
+
+			}
+
+			if ( $_POST ['wcap_popup_heading_color_picker'] ) {
+
+				update_option ( 'wcap_popup_heading_color_picker', $_POST ['wcap_popup_heading_color_picker'] );
+
+			}
+
+			if ( $_POST ['wcap_text_section_text'] ) {
+
+				update_option ( 'wcap_text_section_text', $_POST ['wcap_text_section_text'] );
+
+			}
+
+			if ( $_POST ['wcap_popup_text_color_picker'] ) {
+
+				update_option ( 'wcap_popup_text_color_picker', $_POST ['wcap_popup_text_color_picker'] );
+
+			}
+
+			if ( $_POST ['wcap_email_placeholder_section_input_text'] ) {
+
+				update_option ( 'wcap_email_placeholder_section_input_text', $_POST ['wcap_email_placeholder_section_input_text'] );
+
+			}
+
+			if ( $_POST ['wcap_button_section_input_text'] ) {
+
+				update_option ( 'wcap_button_section_input_text', $_POST ['wcap_button_section_input_text'] );
+
+			}
+
+			if ( $_POST ['wcap_button_color_picker'] ) {
+
+				update_option ( 'wcap_button_color_picker', $_POST ['wcap_button_color_picker'] );
+
+			}
+
+			if ( isset( $_POST ['wcap_button_text_color_picker'] ) ){
+
+				update_option ( 'wcap_button_text_color_picker', $_POST ['wcap_button_text_color_picker'] );
+
+			}
+
+			if ( isset( $_POST ['wcap_non_mandatory_modal_section_fields_input_text'] ) ) {
+
+				update_option( 'wcap_non_mandatory_text', $_POST ['wcap_non_mandatory_modal_section_fields_input_text'] );
+
+			}
+
+
+
+			$custom_pages = isset( $_POST[ 'wcap_page_select' ] ) ? $_POST[ 'wcap_page_select' ] : array();
+
+		    update_option( 'wcap_custom_pages_list', $custom_pages );
+
+
+
+		}
+
+
+
+		/**
+
+    	 * It will add the setting for Heading section on the add to cart modal settings page.
+
+    	 * @param string $wcap_disabled_field It will indicate if field need to be disabled or not.
+
+    	 * @since 6.0
+
+    	 */
+
+        public static function wcap_add_heading_section( $wcap_disabled_field ) {
+
+    	    ?>
+
+            <div id = "wcap_heading_section_div" class = "wcap_heading_section_div wcap_atc_between_fields_space">
+
+                <table id = "wcap_heading_section_table" class = "wcap_heading_section_table">
+
+                    <th id = "wcap_heading_section_table_heading" class ="wcap_heading_section_table_heading"> Modal Heading </th>
+
+                    <tr id = "wcap_heading_section_tr" class = "wcap_heading_section_tr" >
+
+        				<td id = "wcap_heading_section_text_field" class = "wcap_heading_section_text_field test_borders">
+
+        					<input id = "wcap_heading_section_text_email" v-model = "wcap_heading_section_text_email"  name = "wcap_heading_section_text_email"class = "wcap_heading_section_text_email"
+
+        					<?php echo $wcap_disabled_field; ?> readonly value="<?php _e( 'Please enter your email address', 'woocommerce-abandoned-cart' ); ?>">
+
+        				</td>
+
+        				<td id = "wcap_heading_section_text_field_color" class = "wcap_heading_section_text_field_color test_borders">
+
+        					<?php $wcap_popup_heading_color_picker = get_option( 'wcap_popup_heading_color_picker' ); ?>
+
+        					<span class = "colorpickpreview" style = "background:<?php echo $wcap_popup_heading_color_picker; ?>"></span>
+
+        					<input class = "wcap_popup_heading_color_picker colorpick" name = "wcap_popup_heading_color_picker" value = "#737f97" v-model = "wcap_popup_heading_color" v-on:input = "wcap_atc_popup_heading.color = $event.target.value"
+
+					           <?php echo $wcap_disabled_field; ?> readonly >
+
+        				</td>
+
+    			     </tr>
+
+        		</table>
+
+    		</div>
+
+    		<?php
+
+    	}
+
+
+
+    	/**
+
+    	 * It will add the setting for Text displayed below heading section on the add to cart modal settings page.
+
+    	 * @param string $wcap_disabled_field It will indicate if field need to be disabled or not.
+
+    	 * @since 6.0
+
+    	 */
+
+    	public static function wcap_add_text_section( $wcap_disabled_field ) {
+
+    		?>
+
+            <div id = "wcap_text_section_div" class = "wcap_text_section_div wcap_atc_between_fields_space">
+
+                <table id = "wcap_text_section_table" class = "wcap_text_section_table">
+
+                    <th id = "wcap_text_section_table_heading" class = "wcap_text_section_table_heading"> Modal Text </th>
+
+                	<tr id = "wcap_text_section_tr" class = "wcap_text_section_tr" >
+
+                		<td id = "wcap_text_section_text_field" class = "wcap_text_section_text_field test_borders">
+
+                			<input id = "wcap_text_section_text" v-model = "wcap_text_section_text_field" class="wcap_text_section_input_text" name = "wcap_text_section_text"
+
+                			<?php echo $wcap_disabled_field; ?> readonly value="<?php _e( 'To add this item to your cart, please enter your email address.','woocommerce-abandoned-cart' ); ?>">
+
+                		</td>
+
+                		<td id = "wcap_text_section_field_color" class = "wcap_text_section_field_color test_borders">
+
+                			<?php $wcap_atc_popup_text_color = get_option( 'wcap_popup_text_color_picker' ); ?>
+
+                			<span class = "colorpickpreview" style = "background:<?php echo $wcap_atc_popup_text_color; ?>"></span>
+
+                			<input class = "wcap_popup_text_color_picker colorpick" name = "wcap_popup_text_color_picker" value = "#bbc9d2" v-model = "wcap_popup_text_color" v-on:input = "wcap_atc_popup_text.color = $event.target.value"
+
+                			<?php echo $wcap_disabled_field; ?> readonly>
+
+                		</td>
+
+                	</tr>
+
+                </table>
+
+            </div>
+
+    		<?php
+
+		}
+
+
+
+		/**
+
+    	 * It will add the setting for email placeholder on the add to cart modal settings page.
+
+    	 * @param string $wcap_disabled_field It will indicate if field need to be disabled or not.
+
+    	 * @since 6.0
+
+    	 */
+
+    	public static function wcap_email_placeholder_section( $wcap_disabled_field ) {
+
+			?>
+
+    		<div id = "wcap_email_placeholder_section_div" class = "wcap_email_placeholder_section_div wcap_atc_between_fields_space">
+
+	    		<table id = "wcap_email_placeholder_section_table" class = "wcap_email_placeholder_section_table">
+
+	    		<th id = "wcap_email_placeholder_section_table_heading" class = "wcap_email_placeholder_section_table_heading"> Email placeholder </th>
+
+	    			<tr id = "wcap_email_placeholder_section_tr" class = "wcap_email_placeholder_section_tr" >
+
+	    				<td id = "wcap_email_placeholder_section_text_field" class = "wcap_email_placeholder_section_text_field test_borders">
+
+	    					<input id = "wcap_email_placeholder_section_input_text" v-model = "wcap_email_placeholder_section_input_text" class="wcap_email_placeholder_section_input_text" name = "wcap_email_placeholder_section_input_text"
+
+	    					<?php echo $wcap_disabled_field; ?> readonly value="<?php _e('Email address', 'woocommerce-abandoned-cart' ); ?>">
+
+	    				</td>
+
+	    			</tr>
+
+	    		</table>
+
+    		</div>
+
+    		<?php
+
+    	}
+
+
+
+    	/**
+
+    	 * It will add the setting for Add to cart button on the add to cart modal settings page.
+
+    	 * @param string $wcap_disabled_field It will indicate if field need to be disabled or not.
+
+    	 * @since 6.0
+
+    	 */
+
+    	public static function wcap_button_section( $wcap_disabled_field ) {
+
+    		?>
+
+    		<div id = "wcap_button_section_div" class = "wcap_button_section_div wcap_atc_between_fields_space">
+
+	    		<table id = "wcap_button_section_table" class = "wcap_button_section_table">
+
+	    		<th id = "wcap_button_section_table_heading" class="wcap_button_section_table_heading"> Add to cart button text </th>
+
+	    			<tr>
+
+	    				<td id = "wcap_button_section_text_field" class = "wcap_button_section_text_field test_borders">
+
+	    					<input id = "wcap_button_section_input_text" v-model = "wcap_button_section_input_text" class="wcap_button_section_input_text" name = "wcap_button_section_input_text"
+
+	    					<?php echo $wcap_disabled_field ; ?> readonly value="<?php _e( 'Add to Cart', 'woocommerce-abandoned-cart' ); ?>">
+
+	    				</td>
+
+	    			</tr>
+
+	    			<tr id = "wcap_button_color_section_tr" class = "wcap_button_color_section_tr">
+
+	    				<td id = "wcap_button_color_section_text_field" class = "wcap_button_color_section_text_field test_borders">
+
+	    					<?php $wcap_atc_button_bg_color = get_option( 'wcap_button_color_picker' ); ?>
+
+	    					<span class = "colorpickpreview" style = "background:<?php echo $wcap_atc_button_bg_color; ?>"></span>
+
+	    					<input id = "wcap_button_color_picker" value = "#0085ba" v-model ="wcap_button_bg_color" v-on:input="wcap_atc_button.backgroundColor = $event.target.value" class="wcap_button_color_picker colorpick" name = "wcap_button_color_picker"
+
+							<?php echo $wcap_disabled_field; ?> readonly >
+
+	    				</td>
+
+	    				<td id = "wcap_button_text_color_section_text_field" class = "wcap_button_text_color_section_text_field test_borders">
+
+	    					<?php $wcap_button_text_color_picker = get_option('wcap_button_text_color_picker'); ?>
+
+	    					<span class = "colorpickpreview" style = "background:<?php echo $wcap_button_text_color_picker; ?>"></span>
+
+	    					<input id = "wcap_button_text_color_picker" value = "#ffffff" v-model = "wcap_button_text_color" v-on:input = "wcap_atc_button.color = $event.target.value" class="wcap_button_text_color_picker colorpick" name = "wcap_button_text_color_picker"
+
+	    					<?php echo $wcap_disabled_field; ?> readonly>
+
+	    				</td>
+
+					</tr>
+
+	    		</table>
+
+    		</div>
+
+    		<?php
+
+    	}
+
+
+
+		/**
+
+    	 * It will add the setting for Email address mandatory field on the add to cart modal settings page.
+
+    	 * @param string $wcap_disabled_field It will indicate if field need to be disabled or not.
+
+    	 * @since 6.0
+
+    	 */
+
+		public static function wcap_mandatory_modal_section( $wcap_disabled_field ) {
+
+			?>
+
+			<table class = "wcap_atc_between_fields_space">
+
+				<th id = "wcap_button_section_table_heading" class = "wcap_button_section_table_heading"> Email address is mandatory ? </th>
+
+				<tr>
+
+					<td>
+
+					   <?php
+
+					   $wcap_atc_email_mandatory = get_option( 'wcap_atc_mandatory_email' );
+
+				       $active_text   			 = $wcap_atc_email_mandatory;
+
+				       ?>
+
+				       <button type = "button" class = "wcap-switch-atc-modal-mandatory wcap-toggle-atc-modal-mandatory" wcap-atc-switch-modal-mandatory = <?php echo $wcap_atc_email_mandatory; ?>
+
+				       <?php echo $wcap_disabled_field; ?> readonly >
+
+					   <?php echo $active_text; ?> </button>
+
+					</td>
+
+				</tr>
+
+			</table>
+
+    		<?php
+
+    	}
+
+
+
+    	/**
+
+    	 * It will add the setting for Email address non mandatory field on the add to cart modal settings page.
+
+    	 * @param string $wcap_disabled_field It will indicate if field need to be disabled or not.
+
+    	 * @since 6.0
+
+    	 */
+
+    	public static function wcap_non_mandatory_modal_section_field( $wcap_disabled_field ) {
+
+    		$wcap_get_mandatory_field      = get_option( 'wcap_atc_mandatory_email' );
+
+    		$wcap_disabled_email_field     = '';
+
+    		if ( 'on' == $wcap_get_mandatory_field ) {
+
+    			$wcap_disabled_email_field = 'disabled="disabled"';
+
+    		}
+
+			?>
+
+    		<div id = "wcap_non_mandatory_modal_section_fields_div" class = "wcap_non_mandatory_modal_section_fields_div wcap_atc_between_fields_space">
+
+	    		<table id = "wcap_non_mandatory_modal_section_fields_div_table" class = "wcap_non_mandatory_modal_section_fields_div_table">
+
+    	    		<th id = "wcap_non_mandatory_modal_section_fields_table_heading"
+
+    	    		class="wcap_non_mandatory_modal_section_fields_table_heading"> Not mandatory text </th>
+
+	    			<tr id = "wcap_non_mandatory_modal_section_fields_tr" class = "wcap_non_mandatory_modal_section_fields_tr" >
+
+	    				<td id = "wcap_non_mandatory_modal_section_fields_text_field" class = "wcap_non_mandatory_modal_section_fields_text_field test_borders">
+
+	    					<input id = "wcap_non_mandatory_modal_section_fields_input_text" v-model = "wcap_non_mandatory_modal_input_text" class = "wcap_non_mandatory_modal_section_fields_input_text" name = "wcap_non_mandatory_modal_section_fields_input_text" readonly value="<?php _e( 'No Thanks', 'woocommerce-abandoned-cart' ); ?>"
+
+	    					<?php echo $wcap_disabled_field;
+
+	    						  echo $wcap_disabled_email_field;
+
+	    					?> >
+
+	    				</td>
+
+	    			</tr>
+
+	    		</table>
+
+    		</div>
+
+    		<?php
+
+    	}
+
+
+
+    	/**
+
+    	 * It will will show th preview of the Add To cart Popup modal with the changes made on any of the settings for it.
+
+    	 * @param string $wcap_disabled_field It will indicate if field need to be disabled or not.
+
+    	 * @since 6.0
+
+    	 */
+
+    	public static function wcap_add_to_cart_popup_modal_preview( $wcap_disabled_field ) {
+
+
+
+    		?>
+
+    		<div class = "wcap_container">
+
+				<div class = "wcap_popup_wrapper">
+
+				    <div class = "wcap_popup_content">
+
+				        <div class = "wcap_popup_heading_container">
+
+				            <div class = "wcap_popup_icon_container" >
+
+				                <span class = "wcap_popup_icon"  >
+
+				                    <span class = "wcap_popup_plus_sign" v-bind:style = "wcap_atc_button">
+
+				                    </span>
+
+				                </span>
+
+				            </div>
+
+				            <div class = "wcap_popup_text_container">
+
+				                <h2 class = "wcap_popup_heading" v-bind:style = "wcap_atc_popup_heading" ><?php _e( 'Please enter your email address.', 'woocommerce-abandoned-cart' ); ?></h2>
+
+				                <div class = "wcap_popup_text" v-bind:style = "wcap_atc_popup_text" ><?php _e( 'To add this item to your cart, please enter your email address.', 'woocommerce-abandoned-cart' ); ?></div>
+
+				            </div>
+
+				        </div>
+
+				        <div class = "wcap_popup_form">
+
+				            <form action = "" name = "wcap_modal_form">
+
+				                <div class = "wcap_popup_input_field_container"  >
+
+				                    <input class = "wcap_popup_input" type = "text" value = "" name = "email" placeholder ="<?php _e( 'Email address', 'woocommerce-abandoned-cart' ); ?>"
+
+				                    <?php echo $wcap_disabled_field; ?> readonly >
+
+				                </div>
+
+				                <button class = "wcap_popup_button" v-bind:style = "wcap_atc_button"
+
+				                <?php echo $wcap_disabled_field ; ?> ><?php _e( 'Add to Cart', 'woocommerce-abandoned-cart' ); ?></button>
+
+				                <br>
+
+				                <br>
+
+				                <div id = "wcap_non_mandatory_text_wrapper" class = "wcap_non_mandatory_text_wrapper">
+
+				                    <a class = "wcap_popup_non_mandatory_button" href = "" > <?php _e( 'No Thanks', 'woocommerce-abandoned-cart' ); ?></a>
+
+				                </div>
+
+				            </form>
+
+				        </div>
+
+				        <div class = "wcap_popup_close" ></div>
+
+				    </div>
+
+				</div>
+
+			</div>
+
+    		<?php
+
+    	}
+
+	}
+
+}
+

--- a/woocommerce-abandoned-cart/includes/admin/wcap_pro_settings.php
+++ b/woocommerce-abandoned-cart/includes/admin/wcap_pro_settings.php
@@ -4,7 +4,7 @@
 
  * Display all the settings in PRO
 
- * 
+ *
 
  * @since 2.4
 
@@ -22,7 +22,7 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
     class WCAP_Pro_Settings {
 
-    
+
 
         /**
 
@@ -36,13 +36,13 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
 
 
-            add_action( 'admin_init', array( &$this, 'wcal_pro_settings' ) );            
+            add_action( 'admin_init', array( &$this, 'wcal_pro_settings' ) );
 
             add_action( 'wcal_add_new_settings', array(&$this, 'wcap_pro_general_settings' ) );
 
         }
 
-        
+
 
         static function wcap_atc_settings() {
 
@@ -61,7 +61,10 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
                 	<p style="font-size:15px;">
 
-                		<b><i><?php _e( "Upgrade to <a href='$purchase_link' target='_blank'>Abandoned Cart Pro for WooCommerce</a> to enable the feature.", 'woocommerce-abandoned-cart' ); ?></i></b>
+                		<b><i><?php
+                		/* translators: %s Purchase Link */
+                		printf( __( "Upgrade to <a href='%s' target='_blank'>Abandoned Cart Pro for WooCommerce</a> to enable the feature.", 'woocommerce-abandoned-cart' ), $purchase_link);
+                		?></i></b>
 
             		</p>
 
@@ -76,12 +79,12 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
 
         static function wcap_fb_settings() {
-            
+
             ?>
 
                  <form method="post" action="options.php">
 
-                    <?php 
+                    <?php
 
                     //settings_errors();
 
@@ -89,7 +92,7 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
                     do_settings_sections( 'woocommerce_ac_fb_page' );
 
-                    submit_button(); 
+                    submit_button();
 
                     ?>
 
@@ -105,9 +108,9 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
 
 
-        	$upgrade_pro_msg = '<br><b><i>Upgrade to <a href="https://www.tychesoftwares.com/store/premium-plugins/woocommerce-abandoned-cart-pro/" target="_blank">Abandoned Cart Pro for WooCommerce</a> to enable the setting.</i></b>';
+        	$upgrade_pro_msg = __( '<br><b><i>Upgrade to <a href="https://www.tychesoftwares.com/store/premium-plugins/woocommerce-abandoned-cart-pro/" target="_blank">Abandoned Cart Pro for WooCommerce</a> to enable the setting.</i></b>', 'woocommerce-abandoned-cart' );
 
-            
+
 
         	add_settings_field(
 
@@ -121,7 +124,7 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
                 'ac_lite_general_settings_section',
 
-                array( __( "Yes, enable the abandoned cart emails.$upgrade_pro_msg", 'woocommerce-abandoned-cart' ) )
+                array( __( "Yes, enable the abandoned cart emails.", 'woocommerce-abandoned-cart' ) . $upgrade_pro_msg )
 
             );
 
@@ -137,7 +140,7 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
                 'ac_lite_general_settings_section',
 
-                array( __( "For guest users & visitors consider cart abandoned after X minutes of item being added to cart & order not placed.$upgrade_pro_msg", 'woocommerce-abandoned-cart' ) )
+                array( __( "For guest users & visitors consider cart abandoned after X minutes of item being added to cart & order not placed.", 'woocommerce-abandoned-cart' ) . $upgrade_pro_msg )
 
             );
 
@@ -155,7 +158,7 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
                 'ac_lite_general_settings_section',
 
-                array( __( "Abandoned carts of guest users will not be tracked.$upgrade_pro_msg", 'woocommerce-abandoned-cart' ) )
+                array( __( "Abandoned carts of guest users will not be tracked.", 'woocommerce-abandoned-cart' ) . $upgrade_pro_msg )
 
             );
 
@@ -173,7 +176,7 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
                 'ac_lite_general_settings_section',
 
-                array( __( "Abandoned carts of logged-in users will not be tracked.$upgrade_pro_msg", 'woocommerce-abandoned-cart' ) )
+                array( __( "Abandoned carts of logged-in users will not be tracked.", 'woocommerce-abandoned-cart' ) . $upgrade_pro_msg )
 
             );
 
@@ -191,7 +194,7 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
                 'ac_lite_general_settings_section',
 
-                array( __( "If your site URL contain the same key, then it will capture it as an email address of customer.$upgrade_pro_msg", 'woocommerce-abandoned-cart' ) )
+                array( __( "If your site URL contain the same key, then it will capture it as an email address of customer.", 'woocommerce-abandoned-cart' ) . $upgrade_pro_msg )
 
             );
 
@@ -205,7 +208,7 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
             );
 
-            
+
 
             register_setting(
 
@@ -243,7 +246,7 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
             );
 
-            
+
 
             add_settings_field(
 
@@ -257,11 +260,11 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
                 'ac_email_settings_section',
 
-                array( "This setting affects the dimension of the product image in the abandoned cart reminder email.$upgrade_pro_msg", 'woocommerce-abandoned-cart' )
+                array( __( "This setting affects the dimension of the product image in the abandoned cart reminder email.", 'woocommerce-abandoned-cart' ) . $upgrade_pro_msg )
 
             );
 
-            
+
 
             register_setting(
 
@@ -299,7 +302,7 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
                 'ac_cron_job_settings_section',
 
-                array( "Enabling this setting will send the abandoned cart reminder emails to the customer after the set time. If disabled, abandoned cart reminder emails will not be sent using WP Cron. You will need to set cron job manually from cPanel. If you are unsure how to set the cron job, please <a href= mailto:support@tychesoftwares.com>contact us</a> for it.$upgrade_pro_msg", 'woocommerce-abandoned-cart' )
+                array( __( "Enabling this setting will send the abandoned cart reminder emails to the customer after the set time. If disabled, abandoned cart reminder emails will not be sent using WP Cron. You will need to set cron job manually from cPanel. If you are unsure how to set the cron job, please <a href= mailto:support@tychesoftwares.com>contact us</a> for it.", 'woocommerce-abandoned-cart' ) . $upgrade_pro_msg )
 
             );
 
@@ -317,7 +320,7 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
                 'ac_cron_job_settings_section',
 
-                array( "The duration in minutes after which a WP Cron job will run automatically for sending the abandoned cart reminder emails & SMS to the customers.$upgrade_pro_msg", 'woocommerce-abandoned-cart' )
+                array( __( "The duration in minutes after which a WP Cron job will run automatically for sending the abandoned cart reminder emails & SMS to the customers.", 'woocommerce-abandoned-cart' ) . $upgrade_pro_msg )
 
             );
 
@@ -349,7 +352,7 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
                 'ac_restrict_settings_section',
 
-                array( "The carts abandoned from these IP addresses will not be tracked by the plugin. Accepts wildcards, e.g <code>192.168.*</code> will block all IP addresses which starts from \"192.168\". <i>Separate IP addresses with commas.</i>$upgrade_pro_msg", 'woocommerce-abandoned-cart' )
+                array( __( "The carts abandoned from these IP addresses will not be tracked by the plugin. Accepts wildcards, e.g <code>192.168.*</code> will block all IP addresses which starts from \"192.168\". <i>Separate IP addresses with commas.</i>", 'woocommerce-abandoned-cart' ) . $upgrade_pro_msg )
 
             );
 
@@ -367,7 +370,7 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
                 'ac_restrict_settings_section',
 
-                array( "The carts abandoned using these email addresses will not be tracked by the plugin. <i>Separate email addresses with commas.</i>$upgrade_pro_msg", 'woocommerce-abandoned-cart' )
+                array( __( "The carts abandoned using these email addresses will not be tracked by the plugin. <i>Separate email addresses with commas.</i>", 'woocommerce-abandoned-cart' ) . $upgrade_pro_msg )
 
             );
 
@@ -385,7 +388,7 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
                 'ac_restrict_settings_section',
 
-                array( "The carts abandoned from email addresses with these domains will not be tracked by the plugin. <i>Separate email address domains with commas.</i>$upgrade_pro_msg", 'woocommerce-abandoned-cart' )
+                array( __( "The carts abandoned from email addresses with these domains will not be tracked by the plugin. <i>Separate email address domains with commas.</i>", 'woocommerce-abandoned-cart' ) . $upgrade_pro_msg )
 
             );
 
@@ -399,14 +402,14 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
             ?>
 
             <form method="post" action="options.php">
-            
-                <?php 
+
+                <?php
 
                 settings_fields     ( 'woocommerce_sms_settings' );
 
                 do_settings_sections( 'woocommerce_ac_sms_page' );
 
-                submit_button(); 
+                submit_button();
 
                 ?>
 
@@ -452,11 +455,11 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
             </div>
 
-            <?php 
+            <?php
 
         }
 
-        
+
 
         function wcal_pro_settings() {
 
@@ -482,7 +485,7 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
             );
 
-            
+
 
             add_settings_field(
 
@@ -496,11 +499,11 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
                 'wcap_sms_settings_section',
 
-                array( "<i>Enable the ability to send reminder SMS for abandoned carts.</i>$upgrade_pro_msg", 'woocommerce-abandoned-cart' )
+                array( __( "<i>Enable the ability to send reminder SMS for abandoned carts.</i>", 'woocommerce-abandoned-cart' ) . $upgrade_pro_msg )
 
             );
 
-            
+
 
             add_settings_field(
 
@@ -514,11 +517,11 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
                 'wcap_sms_settings_section',
 
-                array( "<i>Must be a Twilio phone number (in E.164 format) or alphanumeric sender ID.</i>$upgrade_pro_msg", 'woocommerce-abandoned-cart' )
+                array( __( "<i>Must be a Twilio phone number (in E.164 format) or alphanumeric sender ID.</i>", 'woocommerce-abandoned-cart' ) . $upgrade_pro_msg )
 
             );
 
-            
+
 
             add_settings_field(
 
@@ -532,11 +535,11 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
                 'wcap_sms_settings_section',
 
-                array( "$upgrade_pro_msg" )
+                array( $upgrade_pro_msg )
 
             );
 
-            
+
 
             add_settings_field(
 
@@ -550,7 +553,7 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
                 'wcap_sms_settings_section',
 
-                array( "$upgrade_pro_msg" )
+                array( $upgrade_pro_msg )
 
             );
 
@@ -566,7 +569,7 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
             );
 
-            
+
 
             register_setting(
 
@@ -576,7 +579,7 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
             );
 
-            
+
 
             register_setting(
 
@@ -586,7 +589,7 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
             );
 
-            
+
 
             register_setting(
 
@@ -624,7 +627,7 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
                 'wcap_fb_settings_section',
 
-                array( "<i>This option will display a checkbox after the Add to cart button for user consent to connect with Facebook.</i>$upgrade_pro_msg", 'woocommerce-abandoned-cart', 'wcap_enable_fb_reminders' )
+                array( __( "<i>This option will display a checkbox after the Add to cart button for user consent to connect with Facebook.</i>", 'woocommerce-abandoned-cart', 'wcap_enable_fb_reminders' ) . $upgrade_pro_msg )
 
             );
 
@@ -642,7 +645,7 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
                 'wcap_fb_settings_section',
 
-                array( "<i>This option will display a checkbox on the pop-up modal to connect with Facebook.</i>$upgrade_pro_msg", 'woocommerce-abandoned-cart', 'wcap_enable_fb_reminders_popup' )
+                array( __( "<i>This option will display a checkbox on the pop-up modal to connect with Facebook.</i>", 'woocommerce-abandoned-cart', 'wcap_enable_fb_reminders_popup' ) . $upgrade_pro_msg )
 
             );
 
@@ -660,15 +663,13 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
                 'wcap_fb_settings_section',
 
-                array( 
+                array(
 
-                    "<i>Select the size of user icon which shall be displayed below the checkbox in case the user is logged in.</i>$upgrade_pro_msg", 
-
-                    'woocommerce-abandoned-cart', 
+                    __( "<i>Select the size of user icon which shall be displayed below the checkbox in case the user is logged in.</i>", 'woocommerce-abandoned-cart' ) . $upgrade_pro_msg,
 
                     'wcap_fb_user_icon',
 
-                    array( 
+                    array(
 
                         'small' => __( 'Small', 'woocommerce-abandoned-cart' ),
 
@@ -680,7 +681,7 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
                         'xlarge' => __( 'Extra Large', 'woocommerce-abandoned-cart' )
 
-                    ) 
+                    )
 
                 )
 
@@ -700,7 +701,7 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
                 'wcap_fb_settings_section',
 
-                array( "<i>Text that will appear above the consent checkbox. HTML tags are also allowed.</i>$upgrade_pro_msg", 'woocommerce-abandoned-cart', 'wcap_fb_consent_text' )
+                array( __( "<i>Text that will appear above the consent checkbox. HTML tags are also allowed.</i>", 'woocommerce-abandoned-cart' ) . $upgrade_pro_msg, 'wcap_fb_consent_text' )
 
             );
 
@@ -718,7 +719,7 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
                 'wcap_fb_settings_section',
 
-                array( "<i>Facebook Page ID in numberic format. You can find your page ID from <a href='https://www.tychesoftwares.com/docs/docs/abandoned-cart-pro-for-woocommerce/send-abandoned-cart-reminder-notifications-using-facebook-messenger#fbpageid' target='_blank'>here</a></i>$upgrade_pro_msg", 'woocommerce-abandoned-cart', 'wcap_fb_page_id' )
+                array( __( "<i>Facebook Page ID in numberic format. You can find your page ID from <a href='https://www.tychesoftwares.com/docs/docs/abandoned-cart-pro-for-woocommerce/send-abandoned-cart-reminder-notifications-using-facebook-messenger#fbpageid' target='_blank'>here</a></i>", 'woocommerce-abandoned-cart' ) . $upgrade_pro_msg, 'wcap_fb_page_id' )
 
             );
 
@@ -736,7 +737,7 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
                 'wcap_fb_settings_section',
 
-                array( "<i>Enter your Messenger App ID</i>$upgrade_pro_msg", 'woocommerce-abandoned-cart', 'wcap_fb_app_id' )
+                array( __( "<i>Enter your Messenger App ID</i>", 'woocommerce-abandoned-cart' ) . $upgrade_pro_msg, 'wcap_fb_app_id' )
 
             );
 
@@ -754,7 +755,7 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
                 'wcap_fb_settings_section',
 
-                array( "<i>Enter your Facebook Page Token</i>$upgrade_pro_msg", 'woocommerce-abandoned-cart', 'wcap_fb_page_token' )
+                array( __( "<i>Enter your Facebook Page Token</i>", 'woocommerce-abandoned-cart' ) . $upgrade_pro_msg, 'wcap_fb_page_token' )
 
             );
 
@@ -772,7 +773,7 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
                 'wcap_fb_settings_section',
 
-                array( "<i>Enter your Verify Token</i>$upgrade_pro_msg", 'woocommerce-abandoned-cart', 'wcap_fb_verify_token' )
+                array( __( "<i>Enter your Verify Token</i>", 'woocommerce-abandoned-cart' ) . $upgrade_pro_msg, 'wcap_fb_verify_token' )
 
             );
 
@@ -858,7 +859,7 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
         }
 
-  
+
 
   		public static function wcap_add_to_cart_popup_settings() {
 
@@ -870,17 +871,17 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
     			$wcap_disabled_field = 'disabled="disabled"';
 
-    		} 
+    		}
 
     		?>
 
 			<div id = "wcap_popup_main_div" class = "wcap_popup_main_div ">
-                
+
     			<table id = "wcap_popup_main_table" class = "wcap_popup_main_table test_borders">
 
     				<tr id = "wcap_popup_main_table_tr" class = "wcap_popup_main_table_tr test_borders">
 
-    					<td id = "wcap_popup_main_table_td_settings" class = "wcap_popup_main_table_td_settings test_borders">    						
+    					<td id = "wcap_popup_main_table_td_settings" class = "wcap_popup_main_table_td_settings test_borders">
 
     						<?php Wcap_Add_Cart_Popup_Modal::wcap_enable_modal_section( $wcap_disabled_field ); ?>
 
@@ -944,7 +945,7 @@ if ( ! class_exists('WCAP_Pro_Settings' ) ) {
 
     	}
 
-      
+
 
     } // end of class
 

--- a/woocommerce-abandoned-cart/includes/classes/class-wcal-templates-table.php
+++ b/woocommerce-abandoned-cart/includes/classes/class-wcal-templates-table.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 // Load WP_List_Table if not loaded
 if ( ! class_exists( 'WP_List_Table' ) ) {
@@ -39,7 +39,7 @@ class WCAL_Templates_Table extends WP_List_Table {
 	 * @since 2.5.3
 	 */
 	public $total_count;
-	
+
     /**
 	 * It will add the bulk action function and other variable needed for the class.
 	 *
@@ -57,7 +57,7 @@ class WCAL_Templates_Table extends WP_List_Table {
 		$this->process_bulk_action();
         $this->base_url = admin_url( 'admin.php?page=woocommerce_ac_page&action=emailtemplates' );
 	}
-	
+
 	/**
 	 * It will prepare the list of the templates, like columns, pagination, sortable column, all data.
 	 * @since 2.5.2
@@ -67,11 +67,11 @@ class WCAL_Templates_Table extends WP_List_Table {
 		$hidden   = array(); // No hidden columns
 		$sortable = $this->templates_get_sortable_columns();
 		$data     = $this->wcal_templates_data();
-		
+
 		$this->_column_headers = array( $columns, $hidden, $sortable );
 		$total_items           = $this->total_count;
 		$this->items           = $data;
-		
+
 		$this->set_pagination_args( array(
 				'total_items' => $total_items,                  	// WE have to calculate the total number of items
 				'per_page'    => $this->per_page,                     	// WE have to determine how many items to show on a page
@@ -79,32 +79,32 @@ class WCAL_Templates_Table extends WP_List_Table {
 		      )
 		);
 	}
-	
+
 	/**
 	 * It will add the columns templates list.
 	 * @return array $columns All columns name.
 	 * @since 2.5.2
 	 */
-	public function get_columns() {	    
+	public function get_columns() {
 	    $columns = array(
  		        'cb'            => '<input type="checkbox" />',
                 'sr'            => __( 'Sr', 'woocommerce-abandoned-cart' ),
 		        'template_name' => __( 'Name Of Template', 'woocommerce-abandoned-cart' ),
 				'sent_time'     => __( 'Sent After Set Time', 'woocommerce-abandoned-cart' ),
-				'activate'  	=> __( 'Active ?', 'woocommerce-abandoned-cart' )			
-		);		
+				'activate'  	=> __( 'Active ?', 'woocommerce-abandoned-cart' )
+		);
 	   return apply_filters( 'wcal_templates_columns', $columns );
-	}	
+	}
 	/**
 	 * It is used to add the check box for the items.
-	 * @param string $item  
-	 * @return string 
+	 * @param string $item
+	 * @return string
 	 * @since 2.5.2
 	 */
-	function column_cb( $item ) {	    
+	function column_cb( $item ) {
 	    $template_id = '';
 	    if( isset( $item->id ) && "" != $item->id ) {
-	       $template_id = $item->id; 
+	       $template_id = $item->id;
 	    }
 	    return sprintf(
 	        '<input type="checkbox" name="%1$s[]" value="%2$s" />',
@@ -112,7 +112,7 @@ class WCAL_Templates_Table extends WP_List_Table {
 	        $template_id
 	    );
 	}
-	
+
 	/**
 	 * We can mention on which column we need the sorting. Here we have template name, email sent time
 	 * @return array $columns Name of the column
@@ -125,75 +125,75 @@ class WCAL_Templates_Table extends WP_List_Table {
 		);
 		return apply_filters( 'wcal_templates_sortable_columns', $columns );
 	}
-	
+
 	/**
-	 * It will add the hover link on the template name. 
+	 * It will add the hover link on the template name.
 	 * This function used for individual delete, edit of row.
 	 * @since 2.5.2
-	 * @param array $template_row_info Contains all the data of the template row 
+	 * @param array $template_row_info Contains all the data of the template row
 	 * @return string $value All hover links, here we have edit and delete
-	 * 
+	 *
 	 */
-	public function column_template_name( $template_row_info ) {	
+	public function column_template_name( $template_row_info ) {
 	    $row_actions = array();
 	    $value = '';
 	    $template_id = 0;
-	    if( isset( $template_row_info->template_name ) ) {	    
-    	    $template_id = $template_row_info->id ; 
-    	    
+	    if( isset( $template_row_info->template_name ) ) {
+    	    $template_id = $template_row_info->id ;
+
     	    $row_actions['edit']   = '<a href="' . wp_nonce_url( add_query_arg( array( 'action' => 'emailtemplates', 'mode'=>'edittemplate', 'id' => $template_row_info->id ), $this->base_url ), 'abandoned_order_nonce') . '">' . __( 'Edit', 'woocommerce-abandoned-cart' ) . '</a>';
     	    $row_actions['delete'] = '<a href="' . wp_nonce_url( add_query_arg( array( 'action' => 'wcal_delete_template', 'template_id' => $template_row_info->id ), $this->base_url ), 'abandoned_order_nonce') . '">' . __( 'Delete', 'woocommerce-abandoned-cart' ) . '</a>';
-    	    
+
     	    $email = $template_row_info->template_name;
-            $value = $email . $this->row_actions( $row_actions );	    
-	    }	
+            $value = $email . $this->row_actions( $row_actions );
+	    }
 	return apply_filters( 'wcal_template_single_column', $value, $template_id, 'email' );
 	}
-    
+
     /**
      * It will generate the templates list data.
      * @globals mixed $wpdb
      * @return array $return_templates_data_display Key and value of all the columns
      * @since 2.5.2
      */
-	public function wcal_templates_data() { 
-		global $wpdb;    		
+	public function wcal_templates_data() {
+		global $wpdb;
 		$return_templates_data = array();
 		$per_page              = $this->per_page;
-		$results               = array();    	 
+		$results               = array();
         $query                 = "SELECT wpet . * FROM `" . $wpdb->prefix . "ac_email_templates_lite` AS wpet ORDER BY day_or_hour desc , frequency asc";
-        $results               = $wpdb->get_results( $query );		
-		$i = 0; 
-		   		
-		foreach ( $results as $key => $value ) {    		   
-		    $return_templates_data[$i] = new stdClass();    		        		        		  
-		    $id                        = $value->id;    		    
+        $results               = $wpdb->get_results( $query );
+		$i = 0;
+
+		foreach ( $results as $key => $value ) {
+		    $return_templates_data[$i] = new stdClass();
+		    $id                        = $value->id;
 		    $query_no_emails           = "SELECT * FROM " . $wpdb->prefix . "ac_sent_history_lite WHERE template_id= %d";
 		    $subject                   = $value->subject;
 		    $body                      = $value->body;
 		    $is_active                 = $value->is_active;
-		
+
 		    if ( $is_active == '1' ) {
 		        $active = "Deactivate";
 		    } else {
 		        $active = "Activate";
 		    }
 		    $frequency                                  = $value->frequency;
-		    $day_or_hour                                = $value->day_or_hour;    		    
+		    $day_or_hour                                = $value->day_or_hour;
 		    $return_templates_data[ $i ]->sr            = $i+1;
 		    $return_templates_data[ $i ]->id            = $id;
 		    $return_templates_data[ $i ]->template_name = $value->template_name;
 		    $return_templates_data[ $i ]->sent_time     = __( $frequency . " " . $day_or_hour . "After Abandonment", 'woocommerce-abandoned-cart' );
 		    $return_templates_data[ $i ]->activate      = $active;
 		    $return_templates_data[ $i ]->is_active     = $is_active;
-		    $i++;  		        		    
+		    $i++;
         }
         $templates_count   = count( $return_templates_data );
         $this->total_count = $templates_count;
     	// sort for order date
 		 if( isset( $_GET['orderby'] ) && $_GET['orderby'] == 'template_name' ) {
     		if( isset($_GET['order'] ) && $_GET['order'] == 'asc' ) {
-				usort( $return_templates_data, array( __CLASS__ , "wcal_class_template_name_asc" ) ); 
+				usort( $return_templates_data, array( __CLASS__ , "wcal_class_template_name_asc" ) );
 			} else {
 				usort( $return_templates_data, array( __CLASS__ , "wcal_class_template_name_dsc") );
 			}
@@ -221,54 +221,54 @@ class WCAL_Templates_Table extends WP_List_Table {
 		        break;
 		    }
 		}
-		
+
 	return apply_filters( 'wcal_templates_table_data', $return_templates_data_display );
 	}
-	
+
 	/**
 	 * It will sort the data alphabetally ascending on the template name.
 	 * @param array | object $value1 All data of the list
 	 * @param array | object $value2 All data of the list
-	 * @return sorted array  
+	 * @return sorted array
 	 * @since 2.5.2
 	 */
 	function wcal_class_template_name_asc( $value1,$value2 ) {
 	    return strcasecmp( $value1->template_name,$value2->template_name );
 	}
-	
+
 	/**
 	 * It will sort the data alphabetally descending on the template name.
 	 * @param array | object $value1 All data of the list
 	 * @param array | object $value2 All data of the list
-	 * @return sorted array  
+	 * @return sorted array
 	 * @since 2.5.2
 	 */
 	function wcal_class_template_name_dsc( $value1,$value2 ) {
 	    return strcasecmp( $value2->template_name,$value1->template_name );
 	}
-	
+
 	/**
 	 * It will sort the data alphanumeric ascending on the template time.
 	 * @param array | object $value1 All data of the list
 	 * @param array | object $value2 All data of the list
-	 * @return sorted array  
+	 * @return sorted array
 	 * @since 2.5.2
 	 */
 	function wcal_class_sent_time_asc( $value1,$value2 ) {
 	    return strnatcasecmp( $value1->sent_time,$value2->sent_time );
 	}
-	
+
 	/**
 	 * It will sort the data alphanumeric descending on the template time.
 	 * @param array | object $value1 All data of the list
 	 * @param array | object $value2 All data of the list
-	 * @return sorted array  
+	 * @return sorted array
 	 * @since 2.5.2
 	 */
 	function wcal_class_sent_time_dsc( $value1,$value2 ) {
 	    return strnatcasecmp( $value2->sent_time,$value1->sent_time );
 	}
-	
+
 	/**
 	 * It will display the data for the templates list
 	 * @param array | object $wcal_abandoned_orders All data of the list
@@ -278,48 +278,50 @@ class WCAL_Templates_Table extends WP_List_Table {
 	 */
 	public function column_default( $wcal_abandoned_orders, $column_name ) {
 	    $value = '';
-	    switch ( $column_name ) {	       
+	    switch ( $column_name ) {
 	        case 'sr' :
 	            if( isset( $wcal_abandoned_orders->sr ) ) {
 	                $value = $wcal_abandoned_orders->sr;
 	            }
-	            break;	            
+	            break;
 			case 'template_name' :
 			    if( isset( $wcal_abandoned_orders->template_name ) ) {
 				    $value = $wcal_abandoned_orders->template_name;
 			    }
-				break;			
+				break;
 			case 'sent_time' :
 			    if( isset( $wcal_abandoned_orders->sent_time ) ) {
 			       $value = $wcal_abandoned_orders->sent_time;
 			    }
-				break;			
+				break;
 			case 'activate' :
-			    if( isset( $wcal_abandoned_orders->activate ) ) {			       
-			       $active    = $wcal_abandoned_orders->activate;
-			       $id        = $wcal_abandoned_orders->id;
-			       $is_active = $wcal_abandoned_orders->is_active;			       
-			       $active    = ''; 
+			    if( isset( $wcal_abandoned_orders->activate ) ) {
+			       $active      = $wcal_abandoned_orders->activate;
+			       $id          = $wcal_abandoned_orders->id;
+			       $is_active   = $wcal_abandoned_orders->is_active;
+			       $active      = '';
+			       $active_text = '';
 			       if ( $is_active == '1' ) {
 			           $active = "on";
+			           $active_text = __( "on", 'woocommerce-abandoned-cart' );
 			       } else {
 			           $active = "off";
+			           $active_text = __( "off", 'woocommerce-abandoned-cart' );
 			       }
-			       $active_text   = __( $active, 'woocommerce-abandoned-cart' ); 
-			       //$value   = '<a href="#" onclick="wcal_activate_email_template('. $id.', '.$is_active.' )"> '.$active_text.'</a>'; 				
+			       //$value   = '<a href="#" onclick="wcal_activate_email_template('. $id.', '.$is_active.' )"> '.$active_text.'</a>';
 			       $value =  '<button type="button" class="wcal-switch wcal-toggle-template-status" '
 					. 'wcal-template-id="'. $id .'" '
 					. 'wcal-template-switch="'. ( $active ) . '">'
-					. $active_text . '</button>';      
+					. $active_text . '</button>';
 			    }
-				break;			
-		    default:			    
+				break;
+		    default:
 				$value = isset( $wcal_abandoned_orders->$column_name ) ? $wcal_abandoned_orders->$column_name : '';
 				break;
-	    }		
+	    }
 	return apply_filters( 'wcal_template_column_default', $value, $wcal_abandoned_orders, $column_name );
 	}
-	
+
 	/**
 	 * It will add the bulk action, here Delete
 	 * @return array

--- a/woocommerce-abandoned-cart/includes/wcal_all_component.php
+++ b/woocommerce-abandoned-cart/includes/wcal_all_component.php
@@ -3,7 +3,7 @@
  * It will Add all the Boilerplate component when we activate the plugin.
  * @author  Tyche Softwares
  * @package Abandoned-Cart-Lite-for-WooCommerce/Admin/Component
- * 
+ *
  */
 if ( ! defined( 'ABSPATH' ) ) {
     exit; // Exit if accessed directly.
@@ -12,10 +12,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( 'Wcal_All_Component' ) ) {
 	/**
 	 * It will Add all the Boilerplate component when we activate the plugin.
-	 * 
+	 *
 	 */
 	class Wcal_All_Component {
-	    
+
 		/**
 		 * It will Add all the Boilerplate component when we activate the plugin.
 		 */
@@ -33,7 +33,7 @@ if ( ! class_exists( 'Wcal_All_Component' ) ) {
                 require_once( "component/welcome-page/ts-welcome.php" );
                 require_once( "component/faq-support/ts-faq-support.php" );
                 require_once( "component/pro-notices-in-lite/ts-pro-notices.php" );
-                
+
                 $wcal_plugin_name          = 'Abandoned Cart Lite for WooCommerce';
                 $wcal_locale               = 'woocommerce-abandoned-cart';
                 $wcal_file_name            = 'woocommerce-abandoned-cart/woocommerce-ac.php';
@@ -66,16 +66,16 @@ if ( ! class_exists( 'Wcal_All_Component' ) ) {
                 $wcal_deativate->init ( $wcal_file_name, $wcal_plugin_name );
 
                 /*new Wcal_TS_Welcome ( $wcal_plugin_name, $wcal_plugin_prefix, $wcal_locale, $wcal_plugin_folder_name, $wcal_plugin_dir_name, $wcal_get_previous_version );*/
-                
+
                 $ts_pro_faq = self::wcal_get_faq ();
                 new Wcal_TS_Faq_Support( $wcal_plugin_name, $wcal_plugin_prefix, $wcal_plugins_page, $wcal_locale, $wcal_plugin_folder_name, $wcal_plugin_slug, $ts_pro_faq );
-                
+
                 /*$ts_pro_notices = self::wcal_get_notice_text ();
 				new Wcal_ts_pro_notices( $wcal_plugin_name, $wcal_lite_plugin_prefix, $wcal_plugin_prefix, $ts_pro_notices, $wcal_file_name, $wcal_pro_file_name );*/
 
             }
         }
-        
+
         /**
          * It will Display the notices in the admin dashboard for the pro vesion of the plugin.
          * @return array $ts_pro_notices All text of the notices
@@ -85,35 +85,44 @@ if ( ! class_exists( 'Wcal_All_Component' ) ) {
 
             $wcal_ac_pro_link = 'https://www.tychesoftwares.com/store/premium-plugins/woocommerce-abandoned-cart-pro/?utm_source=wpnotice&utm_medium=first&utm_campaign=AbandonedCartLitePlugin';
             $wcal_pro_diff    = 'https://www.tychesoftwares.com/differences-between-pro-and-lite-versions-of-abandoned-cart-for-woocommerce-plugin/';
-            $message_first    = wp_kses_post ( __( 'Now that you are all set with the Lite version, you can upgrade to Pro version to take your abandoned cart recovery to the next level. You can capture  customer’s email address when they click Add to Cart, get access to 11 unique, fully responsive email templates, send text messages for recovery & <strong><a target="_blank" href= "'.$wcal_pro_diff.'">much more</a></strong>. <strong><a target="_blank" href= "'.$wcal_ac_pro_link.'">Purchase now</a></strong>.', 'woocommerce-abandoned-cart' ) );  
+            /* translators: %1$s Link to Differences article, %2$s link to pro version */
+            $message_first    = wp_kses_post( sprintf( __( 'Now that you are all set with the Lite version, you can upgrade to Pro version to take your abandoned cart recovery to the next level. You can capture  customer’s email address when they click Add to Cart, get access to 11 unique, fully responsive email templates, send text messages for recovery & <strong><a target="_blank" href= "%1$s">much more</a></strong>. <strong><a target="_blank" href= "%2$s">Purchase now</a></strong>.', 'woocommerce-abandoned-cart' ), $wcal_pro_diff, $wcal_ac_pro_link ) );
 
             $wcal_ac_pro_link = 'https://www.tychesoftwares.com/store/premium-plugins/woocommerce-abandoned-cart-pro/?utm_source=wpnotice&utm_medium=second&utm_campaign=AbandonedCartLitePlugin';
-            $message_two      = wp_kses_post ( __( 'Boost your sales by recovering up to 60% of the abandoned carts with our Abandoned Cart Pro for WooCommerce plugin. You can capture customer email addresses right when they click the Add To Cart button. <strong><a target="_blank" href= "'.$wcal_ac_pro_link.'"> Grab your copy of Abandon Cart Pro plugin now!</a></strong>', 'woocommerce-abandoned-cart' ) );
+            /* translators: %s Link to Abandoned Cart Pro */
+            $message_two      = wp_kses_post( sprintf( __( 'Boost your sales by recovering up to 60% of the abandoned carts with our Abandoned Cart Pro for WooCommerce plugin. You can capture customer email addresses right when they click the Add To Cart button. <strong><a target="_blank" href= "%s"> Grab your copy of Abandon Cart Pro plugin now!</a></strong>', 'woocommerce-abandoned-cart' ), $wcal_ac_pro_link ) );
 
             $wcal_ac_pro_link = 'https://www.tychesoftwares.com/store/premium-plugins/woocommerce-abandoned-cart-pro/?utm_source=wpnotice&utm_medium=third&utm_campaign=AbandonedCartLitePlugin';
-            $message_three    = wp_kses_post ( __( 'Don\'t loose your sales to abandoned carts. Use our Abandon Cart Pro plugin & start recovering your lost sales in less then 60 seconds. <strong><a target="_blank" href= "'.$wcal_ac_pro_link.'">Grab it now!</a></strong>.', 'woocommerce-abandoned-cart' ) );
+            /* translators: %s Link to Abandoned Cart Pro */
+            $message_three    = wp_kses_post( sprintf( __( 'Don\'t loose your sales to abandoned carts. Use our Abandon Cart Pro plugin & start recovering your lost sales in less then 60 seconds. <strong><a target="_blank" href= "%s">Grab it now!</a></strong>.', 'woocommerce-abandoned-cart' ), $wcal_ac_pro_link ) );
 
             $wcal_ac_pro_link = 'https://www.tychesoftwares.com/store/premium-plugins/woocommerce-abandoned-cart-pro/?utm_source=wpnotice&utm_medium=fourth&utm_campaign=AbandonedCartLitePlugin';
-            $message_four     = wp_kses_post ( __( 'Send Abandoned Cart reminders that actually convert. Take advantage of our fully responsive email templates designed specially with an intent to trigger conversion. <strong><a target="_blank" href= "'.$wcal_ac_pro_link.'">Purchase now</a></strong>.', 'woocommerce-abandoned-cart' ) );
+            /* translators: %s Link to Abandoned Cart Pro */
+            $message_four     = wp_kses_post( sprintf( __( 'Send Abandoned Cart reminders that actually convert. Take advantage of our fully responsive email templates designed specially with an intent to trigger conversion. <strong><a target="_blank" href= "%s">Purchase now</a></strong>.', 'woocommerce-abandoned-cart' ), $wcal_ac_pro_link ) );
 
             $wcal_ac_pro_link = 'https://www.tychesoftwares.com/store/premium-plugins/woocommerce-abandoned-cart-pro/?utm_source=wpnotice&utm_medium=fifth&utm_campaign=AbandonedCartLitePlugin';
-            $message_five     = wp_kses_post ( __( 'Increase your store sales by recovering your abandoned carts for just $119. No profit sharing, no monthly fees. Our Abandoned Cart Pro plugin comes with a 30 day money back guarantee as well. :) Use coupon code ACPRO20 & save $24!<br>
-            <strong><a target="_blank" href= "'.$wcal_ac_pro_link.'">Grab your copy now!</a></strong>', 'woocommerce-abandoned-cart' ) );
+            /* translators: %s Link to Abandoned Cart Pro */
+            $message_five     = wp_kses_post( sprintf( __( 'Increase your store sales by recovering your abandoned carts for just $119. No profit sharing, no monthly fees. Our Abandoned Cart Pro plugin comes with a 30 day money back guarantee as well. :) Use coupon code ACPRO20 & save $24!<br>
+            <strong><a target="_blank" href= "%s">Grab your copy now!</a></strong>', 'woocommerce-abandoned-cart' ), $wcal_ac_pro_link ) );
 
             $_link            = 'https://www.tychesoftwares.com/store/premium-plugins/order-delivery-date-for-woocommerce-pro-21/?utm_source=wpnotice&utm_medium=sixth&utm_campaign=AbandonedCartLitePlugin';
-            $message_six      = wp_kses_post ( __( 'Reduce cart abandonment rate by 57% with our Order Delivery Date Pro WooCommerce plugin. You can Create Delivery Settings by Shipping Zones & Shipping Classes. <br>Use discount code "ORDPRO20" and grab 20% discount on the purchase of the plugin. The discount code is valid only for the first 20 customers. <strong><a target="_blank" href= "'.$_link.'">Purchase now</a></strong>', 'woocommerce-abandoned-cart' ) );
+            /* translators: %s Link to Order Delivery Date Pro */
+            $message_six      = wp_kses_post( sprintf( __( 'Reduce cart abandonment rate by 57% with our Order Delivery Date Pro WooCommerce plugin. You can Create Delivery Settings by Shipping Zones & Shipping Classes. <br>Use discount code "ORDPRO20" and grab 20% discount on the purchase of the plugin. The discount code is valid only for the first 20 customers. <strong><a target="_blank" href= "%s">Purchase now</a></strong>', 'woocommerce-abandoned-cart' ), $_link ) );
 
             $_link            = 'https://www.tychesoftwares.com/store/premium-plugins/product-delivery-date-pro-for-woocommerce/?utm_source=wpnotice&utm_medium=seventh&utm_campaign=AbandonedCartLitePlugin';
-            $message_seven    = wp_kses_post ( __( 'Allow your customers to select the Delivery Date on Single Product Page using our Product Delivery Date pro for WooCommerce Plugin. <br> 
-            <strong><a target="_blank" href= "'.$_link.'">Shop now</a></strong> & be one of the 20 customers to get 20% discount on the plugin price. Use the code "PRDPRO20". Hurry!!', 'woocommerce-abandoned-cart' ) );
-            
+            /* translators: %s Link to Order Delivery Date Pro */
+            $message_seven    = wp_kses_post( sprintf( __( 'Allow your customers to select the Delivery Date on Single Product Page using our Product Delivery Date pro for WooCommerce Plugin. <br>
+            <strong><a target="_blank" href= "%s">Shop now</a></strong> & be one of the 20 customers to get 20% discount on the plugin price. Use the code "PRDPRO20". Hurry!!', 'woocommerce-abandoned-cart' ), $_link ) );
+
             $_link            = 'https://www.tychesoftwares.com/store/premium-plugins/woocommerce-booking-plugin/?utm_source=wpnotice&utm_medium=eight&utm_campaign=AbandonedCartLitePlugin';
-            $message_eight    = wp_kses_post ( __( ' Allow your customers to book an appointment or rent an apartment with our Booking and Appointment for WooCommerce plugin. You can also sell your product as a resource or integrate with a few Vendor plugins. <br>Shop now & Save 20% on the plugin with the code "BKAP20". Only for first 20 customers. <strong><a target="_blank" href= "'.$_link.'">Have it now!</a></strong>', 'woocommerce-abandoned-cart' ) );
-            
+            /* translators: %s Link to WooCommerce Booking Plugin */
+            $message_eight    = wp_kses_post( sprintf( __( 'Allow your customers to book an appointment or rent an apartment with our Booking and Appointment for WooCommerce plugin. You can also sell your product as a resource or integrate with a few Vendor plugins. <br>Shop now & Save 20% on the plugin with the code "BKAP20". Only for first 20 customers. <strong><a target="_blank" href= "%s">Have it now!</a></strong>', 'woocommerce-abandoned-cart' ), $_link ) );
+
             $_link            = 'https://www.tychesoftwares.com/store/premium-plugins/deposits-for-woocommerce/?utm_source=wpnotice&utm_medium=eight&utm_campaign=AbandonedCartLitePlugin';
-            $message_nine     = wp_kses_post ( __( ' Allow your customers to pay deposits on products using our Deposits for WooCommerce plugin. <br>
-            <strong><a target="_blank" href= "'.$_link.'">Purchase now</a></strong> & Grab 20% discount with the code "DFWP20". The discount code is valid only for the first 20 customers.', 'woocommerce-abandoned-cart' ) );
-			
+            /* translators: %s Link to Deposits for WooCommerce */
+            $message_nine     = wp_kses_post( sprintf( __( ' Allow your customers to pay deposits on products using our Deposits for WooCommerce plugin. <br>
+            <strong><a target="_blank" href= "%s">Purchase now</a></strong> & Grab 20% discount with the code "DFWP20". The discount code is valid only for the first 20 customers.', 'woocommerce-abandoned-cart' ), $_link ) );
+
             $ts_pro_notices = array (
                 1 => $message_first,
                 2 => $message_two,
@@ -128,11 +137,11 @@ if ( ! class_exists( 'Wcal_All_Component' ) ) {
 
             return $ts_pro_notices;
         }
-		
+
 		/**
          * It will contain all the FAQ which need to be display on the FAQ page.
          * @return array $ts_faq All questions and answers.
-         * 
+         *
          */
         public static function wcal_get_faq () {
 
@@ -144,7 +153,7 @@ if ( ! class_exists( 'Wcal_All_Component' ) ) {
                         'answer'   => 'Please ensure you have at least one Email template "Active". As only active email templates are sent to recover the abandoned carts.
                         <br/><br/>
                         For sending the abandoned cart notification emails automatically, we use WP-Cron. If you have Email templates activated and still notification are not sent, then you can debug the issue by following this <a href = "https://www.tychesoftwares.com/docs/docs/abandoned-cart-pro-for-woocommerce/wp_alternate_cron/?utm_source=userwebsite&utm_medium=link&utm_campaign=AbandonedCartProFAQTab" target="_blank" >post</a>.'
-                    ), 
+                    ),
                 2 => array (
                         'question' => 'How is the email address of the customers captured?',
                         'answer'   => 'Our plugin captures visitor emails in real-time as they are typing it in to the email address field on the checkout page, so you don\'t need to worry about them changing their mind at the last second.
@@ -188,7 +197,7 @@ if ( ! class_exists( 'Wcal_All_Component' ) ) {
                 10 => array (
 						'question' => 'There was a problem creating an email template on Multisite.',
 						'answer'   => 'On Multisite, if you have activated the plugin from Network site then please deactivate it and activate the Abandoned Cart Lite plugin from an Individual site. So, one default email template will be created on the activation of the plugin and you can create new email template.'
-                )    
+                )
             );
 
             return $ts_faq;

--- a/woocommerce-abandoned-cart/includes/wcal_data_tracking_message.php
+++ b/woocommerce-abandoned-cart/includes/wcal_data_tracking_message.php
@@ -15,7 +15,7 @@ if ( ! class_exists( 'Wcal_Tracking_msg' ) ) {
      * @since    4.9
      */
     class Wcal_Tracking_msg {
-        
+
         public function __construct() {
             // Checkout page notice for guest users
             add_filter( 'woocommerce_checkout_fields' , array( &$this, 'wcal_add_gdpr_msg' ), 10, 1 );
@@ -25,23 +25,23 @@ if ( ! class_exists( 'Wcal_Tracking_msg' ) ) {
             add_action( 'woocommerce_before_shop_loop', array( &$this, 'wcal_add_logged_msg' ), 10 );
             //add_action( 'woocommerce_after_shop_loop_item', array( &$this, 'wcal_add_logged_msg' ), 10 );
         }
-        
+
         /**
          * Adds a message to be displayed above Billing_email
          * field on Checkout page for guest users.
-         * 
+         *
          * @param array $fields - List of fields on Checkout page
          * @return array $fields - List of fields on Checkout page
-         * 
+         *
          * @hook woocommerce_checkout_fields
          * @since 4.9
          */
         static function wcal_add_gdpr_msg( $fields ) {
-            
+
             if ( ! is_user_logged_in() ) {
                 // check if any message is present in the settings
                 $guest_msg = get_option( 'wcal_guest_cart_capture_msg' );
-                
+
                 if ( isset( $guest_msg ) && '' != $guest_msg ) {
                     $existing_label = $fields[ 'billing' ][ 'billing_email' ][ 'label' ];
                     $fields[ 'billing' ][ 'billing_email' ][ 'label' ] = $existing_label . "<br><small>$guest_msg</small>";
@@ -49,26 +49,26 @@ if ( ! class_exists( 'Wcal_Tracking_msg' ) ) {
             }
             return $fields;
         }
-        
+
         /**
          * Adds a message to be displayed for logged in users
          * Called on Shop & Product page
-         * 
+         *
          * @hook woocommerce_after_add_to_cart_button
          *       woocommerce_before_shop_loop
-         * @since 4.9      
+         * @since 4.9
          */
         static function wcal_add_logged_msg() {
             if ( is_user_logged_in() ) {
-                
+
                 $registered_msg = get_option( 'wcal_logged_cart_capture_msg' );
-                
+
                 if ( isset( $registered_msg ) && '' != $registered_msg ) {
-                    echo "<p><small>" . __( $registered_msg, 'woocommerce-abandoned-cart' ) . "</small></p>";
+                    echo "<p><small>" . $registered_msg . "</small></p>";
                 }
             }
         }
-        
+
     } // end of class
     $Wcal_Tracking_msg = new Wcal_Tracking_msg();
 } // end IF

--- a/woocommerce-abandoned-cart/woocommerce-ac.php
+++ b/woocommerce-abandoned-cart/woocommerce-ac.php
@@ -1,9 +1,9 @@
-<?php 
+<?php
 /*
 * Plugin Name: Abandoned Cart Lite for WooCommerce
 * Plugin URI: http://www.tychesoftwares.com/store/premium-plugins/woocommerce-abandoned-cart-pro
-* Description: This plugin captures abandoned carts by logged-in users & emails them about it. 
-* <strong><a href="http://www.tychesoftwares.com/store/premium-plugins/woocommerce-abandoned-cart-pro">Click here to get the 
+* Description: This plugin captures abandoned carts by logged-in users & emails them about it.
+* <strong><a href="http://www.tychesoftwares.com/store/premium-plugins/woocommerce-abandoned-cart-pro">Click here to get the
 * PRO Version.</a></strong>
 * Version: 5.4
 * Author: Tyche Softwares
@@ -44,7 +44,7 @@ add_filter( 'cron_schedules', 'wcal_add_cron_schedule' );
  * @since 1.3
  * @package Abandoned-Cart-Lite-for-WooCommerce/Cron
  */
-function wcal_add_cron_schedule( $schedules ) { 
+function wcal_add_cron_schedule( $schedules ) {
     $schedules['15_minutes_lite'] = array(
                 'interval'  => 900, // 15 minutes in seconds
                 'display'   => __( 'Once Every Fifteen Minutes' ),
@@ -56,7 +56,7 @@ function wcal_add_cron_schedule( $schedules ) {
  * Schedule an action if it's not already scheduled.
  * @since 1.3
  * @package Abandoned-Cart-Lite-for-WooCommerce/Cron
- */ 
+ */
 if ( ! wp_next_scheduled( 'woocommerce_ac_send_email_action' ) ) {
     wp_schedule_event( time(), '15_minutes_lite', 'woocommerce_ac_send_email_action' );
 }
@@ -70,7 +70,7 @@ if( ! wp_next_scheduled( 'wcal_clear_carts' ) ) {
     wp_schedule_event( time(), 'daily', 'wcal_clear_carts' );
 }
 /**
- * Hook into that action that'll fire every 15 minutes 
+ * Hook into that action that'll fire every 15 minutes
  */
 add_action( 'woocommerce_ac_send_email_action', 'wcal_send_email_cron' );
 
@@ -89,10 +89,10 @@ function wcal_send_email_cron() {
      * woocommerce_abandon_cart_lite class
      **/
 if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
-    
+
 
     /**
-     * It will add the hooks, filters, menu and the variables and all the necessary actions for the plguins which will be used 
+     * It will add the hooks, filters, menu and the variables and all the necessary actions for the plguins which will be used
      * all over the plugin.
      * @since 1.0
      * @package Abandoned-Cart-Lite-for-WooCommerce/Core
@@ -103,33 +103,33 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
         var $six_hours;
         var $twelve_hours;
         var $one_day;
-        var $one_week;          
+        var $one_week;
         var $duration_range_select = array();
         var $start_end_dates       = array();
         /**
          * The constructor will add the hooks, filters and the variable which will be used all over the plugin.
          * @since 1.0
-         * 
+         *
          */
-        public function __construct() {  
+        public function __construct() {
             if ( !defined( 'WCAL_PLUGIN_URL' ) ) {
                 define('WCAL_PLUGIN_URL', untrailingslashit(plugins_url('/', __FILE__)) );
-            }       
+            }
             $this->one_hour     = 60 * 60;
             $this->three_hours  = 3 * $this->one_hour;
             $this->six_hours    = 6 * $this->one_hour;
             $this->twelve_hours = 12 * $this->one_hour;
             $this->one_day      = 24 * $this->one_hour;
-            $this->one_week     = 7 * $this->one_day;           
+            $this->one_week     = 7 * $this->one_day;
             $this->duration_range_select = array( 'yesterday'      => 'Yesterday',
                                                   'today'          => 'Today',
                                                   'last_seven'     => 'Last 7 days',
                                                   'last_fifteen'   => 'Last 15 days',
                                                   'last_thirty'    => 'Last 30 days',
                                                   'last_ninety'    => 'Last 90 days',
-                                                  'last_year_days' => 'Last 365'    
+                                                  'last_year_days' => 'Last 365'
                                                  );
-            
+
             $this->start_end_dates = array( 'yesterday'      => array( 'start_date' => date( "d M Y", ( current_time( 'timestamp' ) - 24*60*60 ) ),
                                             'end_date'       => date( "d M Y", ( current_time( 'timestamp' ) - 7*24*60*60 ) ) ),
                                             'today'          => array( 'start_date' => date( "d M Y", ( current_time( 'timestamp' ) ) ),
@@ -143,19 +143,19 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                             'last_ninety'    => array( 'start_date' => date( "d M Y", ( current_time( 'timestamp' ) - 90*24*60*60 ) ),
                                             'end_date'       => date( "d M Y", ( current_time( 'timestamp' ) ) ) ),
                                             'last_year_days' => array( 'start_date' => date( "d M Y", ( current_time( 'timestamp' ) - 365*24*60*60 ) ),
-                                            'end_date'       => date( "d M Y", ( current_time( 'timestamp' ) ) ) )                  
+                                            'end_date'       => date( "d M Y", ( current_time( 'timestamp' ) ) ) )
                                            );
-            
+
             // Initialize settings
             register_activation_hook ( __FILE__,                        array( &$this, 'wcal_activate' ) );
 
             // Background Processing for Cron
             require_once( 'cron/wcal_send_email.php' );
             require_once( 'includes/background-processes/wcal_process_base.php' );
-            
-            // WordPress Administration Menu 
+
+            // WordPress Administration Menu
             add_action ( 'admin_menu',                                  array( &$this, 'wcal_admin_menu' ) );
-            
+
             // Actions to be done on cart update
             add_action( 'woocommerce_add_to_cart',                      array( &$this, 'wcal_store_cart_timestamp' ), 100 );
             add_action( 'woocommerce_cart_item_removed',                array( &$this, 'wcal_store_cart_timestamp' ), 100 );
@@ -164,48 +164,48 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             add_action( 'woocommerce_calculate_totals',                 array( &$this, 'wcal_store_cart_timestamp' ), 100 );
 
             add_action ( 'admin_init',                                  array( &$this, 'wcal_action_admin_init' ) );
-            
+
             // Update the options as per settings API
             add_action ( 'admin_init',                                  array( &$this, 'wcal_update_db_check' ) );
 
             // Wordpress settings API
             add_action( 'admin_init',                                   array( &$this, 'wcal_initialize_plugin_options' ) );
-            
+
             // Language Translation
             add_action ( 'init',                                        array( &$this, 'wcal_update_po_file' ) );
 
             add_action ( 'init',                                        array ( &$this, 'wcal_add_component_file')  );
-            
+
             // track links
             add_filter( 'template_include',                             array( &$this, 'wcal_email_track_links' ), 99, 1 );
-            
+
             //It will used to unsubcribe the emails.
             add_action( 'template_include',                             array( &$this, 'wcal_email_unsubscribe'),99, 1 );
-            
+
             add_action ( 'admin_enqueue_scripts',                       array( &$this, 'wcal_enqueue_scripts_js' ) );
             add_action ( 'admin_enqueue_scripts',                       array( &$this, 'wcal_enqueue_scripts_css' ) );
 			//delete abandoned order after X number of days
             if ( class_exists( 'wcal_delete_bulk_action_handler' ) ) {
                 add_action( 'wcal_clear_carts',                         array( 'wcal_delete_bulk_action_handler', 'wcal_delete_abandoned_carts_after_x_days' ) );
             }
-            
+
             if ( is_admin() ) {
-                // Load "admin-only" scripts here               
+                // Load "admin-only" scripts here
                 add_action ( 'admin_head',                              array( &$this, 'wcal_action_send_preview' ) );
                 add_action ( 'wp_ajax_wcal_preview_email_sent',         array( &$this, 'wcal_preview_email_sent' ) );
-                add_action ( 'wp_ajax_wcal_toggle_template_status',     array( &$this, 'wcal_toggle_template_status' ) );   
+                add_action ( 'wp_ajax_wcal_toggle_template_status',     array( &$this, 'wcal_toggle_template_status' ) );
 
                 add_filter( 'ts_tracker_data',                          array( 'wcal_common', 'ts_add_plugin_tracking_data' ), 10, 1 );
                 add_filter( 'ts_tracker_opt_out_data',                  array( 'wcal_common', 'ts_get_data_for_opt_out' ), 10, 1 );
                 add_filter( 'ts_deativate_plugin_questions',            array( &$this,  'wcal_deactivate_add_questions' ), 10, 1 );
             }
-             
+
             // Plugin Settings link in WP->Plugins page
             $plugin = plugin_basename( __FILE__ );
             add_action( "plugin_action_links_$plugin",                  array( &$this, 'wcal_settings_link' ) );
-            
+
             add_action( 'admin_init',                                                  array( $this,   'wcal_preview_emails' ) );
-            add_action( 'init',                                                        array( $this,   'wcal_app_output_buffer') );         
+            add_action( 'init',                                                        array( $this,   'wcal_app_output_buffer') );
 
             add_filter( 'admin_footer_text',                                           array( $this,   'wcal_admin_footer_text' ), 1 );
 
@@ -213,7 +213,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
 
             include_once 'includes/frontend/wcal_frontend.php';
         }
-	
+
         /**
          * Add Settings link to WP->Plugins page
          * @since 5.3.0
@@ -232,7 +232,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
         public static function wcal_add_component_file () {
             if ( is_admin() ) {
                 require_once( 'includes/wcal_all_component.php' );
-                
+
             }
         }
         /**
@@ -249,7 +249,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                     'text'              => __( "Emails are not being sent to customers.", "woocommerce-abandoned-cart" ),
                     'input_type'        => '',
                     'input_placeholder' => ''
-                    ), 
+                    ),
                 1 =>  array(
                     'id'                => 5,
                     'text'              => __( "Capturing of cart and other information was not satisfactory.", "woocommerce-abandoned-cart" ),
@@ -288,9 +288,9 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                 $message = '';
                 // create a new email
                 if ( $woocommerce->version < '2.3' ) {
-                    global $email_heading;                   
+                    global $email_heading;
                     ob_start();
-                    
+
                     include( 'views/wcal-wc-email-template-preview.php' );
                     $mailer        = WC()->mailer();
                     $message       = ob_get_clean();
@@ -298,22 +298,22 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                     $message       =  $mailer->wrap_message( $email_heading, $message );
                 } else {
                     // load the mailer class
-                    $mailer        = WC()->mailer(); 
+                    $mailer        = WC()->mailer();
                     // get the preview email subject
-                    $email_heading = __( 'Abandoned cart Email Template', 'woocommerce-abandoned-cart' );       
+                    $email_heading = __( 'Abandoned cart Email Template', 'woocommerce-abandoned-cart' );
                     // get the preview email content
                     ob_start();
                     include( 'views/wcal-wc-email-template-preview.php' );
-                    $message       = ob_get_clean();        
+                    $message       = ob_get_clean();
                     // create a new email
-                    $email         = new WC_Email();        
+                    $email         = new WC_Email();
                     // wrap the content with the email template and then add styles
                     $message       = $email->style_inline( $mailer->wrap_message( $email_heading, $message ) );
-                }       
+                }
                 echo $message;
                 exit;
             }
-        
+
             if ( isset( $_GET['wcal_preview_mail'] ) ) {
                 if ( ! wp_verify_nonce( $_REQUEST['_wpnonce'], 'woocommerce-abandoned-cart' ) ) {
                     die( 'Security check' );
@@ -321,7 +321,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                 // get the preview email content
                 ob_start();
                 include( 'views/wcal-email-template-preview.php' );
-                $message = ob_get_clean();        
+                $message = ob_get_clean();
                 // print the preview email
                 echo $message;
                 exit;
@@ -348,20 +348,20 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                 load_plugin_textdomain( $domain, FALSE, basename( dirname( __FILE__ ) ) . '/i18n/languages/' );
             }
         }
-    
+
         /**
          * It will create the plugin tables & the options reqired for plugin.
          * @hook register_activation_hook
          * @globals mixed $wpdb
          * @since 1.0
-         */                             
+         */
         function wcal_activate() {
-            global $wpdb; 
+            global $wpdb;
             $wcap_collate = '';
             if ( $wpdb->has_cap( 'collation' ) ) {
                 $wcap_collate = $wpdb->get_charset_collate();
             }
-            $table_name = $wpdb->prefix . "ac_email_templates_lite";            
+            $table_name = $wpdb->prefix . "ac_email_templates_lite";
             $sql = "CREATE TABLE IF NOT EXISTS $table_name (
                     `id` int(11) NOT NULL AUTO_INCREMENT,
                     `subject` text NOT NULL,
@@ -375,24 +375,24 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                     `wc_email_header` varchar(50) NOT NULL,
                     PRIMARY KEY (`id`)
                     ) $wcap_collate AUTO_INCREMENT=1 ";
-        
+
             require_once ( ABSPATH . 'wp-admin/includes/upgrade.php' );
             dbDelta( $sql );
-            
+
             // $table_name = $wpdb->prefix . "ac_email_templates_lite";
             // $check_template_table_query = "SHOW COLUMNS FROM $table_name LIKE 'is_wc_template' ";
             // $results = $wpdb->get_results( $check_template_table_query );
-             
+
             // if ( count( $results ) == 0 ) {
             //     $alter_template_table_query = "ALTER TABLE $table_name
             //     ADD COLUMN `is_wc_template` enum('0','1') COLLATE utf8mb4_unicode_ci NOT NULL AFTER `template_name`,
             //     ADD COLUMN `default_template` int(11) NOT NULL AFTER `is_wc_template`";
-                
+
             //     $wpdb->get_results( $alter_template_table_query );
             // }
-            
+
             $sent_table_name = $wpdb->prefix . "ac_sent_history_lite";
-        
+
             $sql_query = "CREATE TABLE IF NOT EXISTS $sent_table_name (
                         `id` int(11) NOT NULL auto_increment,
                         `template_id` varchar(40) collate utf8_unicode_ci NOT NULL,
@@ -401,12 +401,12 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                         `sent_email_id` text COLLATE utf8_unicode_ci NOT NULL,
                         PRIMARY KEY  (`id`)
                         ) $wcap_collate AUTO_INCREMENT=1 ";
-             
+
             require_once ( ABSPATH . 'wp-admin/includes/upgrade.php' );
             dbDelta ( $sql_query );
-                     
+
             $ac_history_table_name = $wpdb->prefix . "ac_abandoned_cart_history_lite";
-             
+
             $history_query = "CREATE TABLE IF NOT EXISTS $ac_history_table_name (
                              `id` int(11) NOT NULL AUTO_INCREMENT,
                              `user_id` int(11) NOT NULL,
@@ -419,13 +419,13 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                              `session_id` varchar(50) COLLATE utf8_unicode_ci NOT NULL,
                              PRIMARY KEY (`id`)
                              ) $wcap_collate";
-                     
+
             require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
             dbDelta( $history_query );
             // Default templates:  function call to create default templates.
             $check_table_empty  = $wpdb->get_var( "SELECT COUNT(*) FROM `" . $wpdb->prefix . "ac_email_templates_lite`" );
-    
-            if ( ! get_option( 'wcal_new_default_templates' ) ) {         
+
+            if ( ! get_option( 'wcal_new_default_templates' ) ) {
                 if ( 0 == $check_table_empty ) {
                     $default_template = new wcal_default_template_settings;
                     $default_template->wcal_create_default_templates();
@@ -435,8 +435,8 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
 
             $guest_table        = $wpdb->prefix."ac_guest_abandoned_cart_history_lite" ;
             $query_guest_table  = "SHOW TABLES LIKE '$guest_table' ";
-            $result_guest_table = $wpdb->get_results( $query_guest_table );          
-            
+            $result_guest_table = $wpdb->get_results( $query_guest_table );
+
             if ( 0 == count( $result_guest_table ) ) {
                 $ac_guest_history_table_name = $wpdb->prefix . "ac_guest_abandoned_cart_history_lite";
                 $ac_guest_history_query = "CREATE TABLE IF NOT EXISTS $ac_guest_history_table_name (
@@ -466,7 +466,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                 ) $wcap_collate AUTO_INCREMENT=63000000";
                 require_once( ABSPATH . 'wp-admin/includes/upgrade.php');
                 $wpdb->query( $ac_guest_history_query );
-            } 
+            }
 
             /**
              * This is add for thos user who Install the plguin first time.
@@ -474,7 +474,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
              */
             if ( ! get_option( 'ac_lite_track_guest_cart_from_cart_page' ) ) {
                 add_option( 'ac_lite_track_guest_cart_from_cart_page', 'on' );
-            } 
+            }
             if ( ! get_option( 'wcal_from_name' ) ) {
                 add_option( 'wcal_from_name', 'Admin' );
             }
@@ -482,14 +482,14 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             if ( ! get_option( 'wcal_from_email' ) ) {
                 add_option( 'wcal_from_email', $wcal_get_admin_email );
             }
-            
+
             if ( ! get_option( 'wcal_reply_email' ) ) {
                 add_option( 'wcal_reply_email', $wcal_get_admin_email );
             }
 
             do_action( 'wcal_activate' );
-        }     
-    
+        }
+
         /**
          * It will add the section, field, & registres the plugin fields using Settings API.
          * @hook admin_init
@@ -504,7 +504,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                 array( $this, 'ac_lite_general_options_callback' ), // Callback used to render the description of the section
                 'woocommerce_ac_page'                               // Page on which to add this section of options
             );
-        
+
             add_settings_field(
                 'ac_lite_cart_abandoned_time',
                 __( 'Cart abandoned cut-off time', 'woocommerce-abandoned-cart' ),
@@ -523,7 +523,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                 array( __( 'Automatically delete abandoned cart orders after X days.', 'woocommerce-abandoned-cart' ) )
             );
 
-            
+
             add_settings_field(
                 'ac_lite_email_admin_on_recovery',
                 __( 'Email admin On Order Recovery', 'woocommerce-abandoned-cart' ),
@@ -533,7 +533,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                 array( __( 'Sends email to Admin if an Abandoned Cart Order is recovered.', 'woocommerce-abandoned-cart' ) )
             );
 
-            
+
             add_settings_field(
             'ac_lite_track_guest_cart_from_cart_page',
             __( 'Start tracking from Cart Page', 'woocommerce-abandoned-cart' ),
@@ -551,7 +551,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                 'ac_lite_general_settings_section',
                 array( __( '<br>In compliance with GDPR, add a message on the Checkout page to inform Guest users of how their data is being used.<br><i>For example: Your email address will help us support your shopping experience throughout the site. Please check our Privacy Policy to see how we use your personal data.</i>', 'woocommerce-abandoned-cart' ) )
             );
-            
+
             add_settings_field(
                 'wcal_logged_cart_capture_msg',
                 __( 'Message to be displayed for registered users when tracking their carts.', 'woocommerce-abandoned-cart' ),
@@ -560,19 +560,19 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                 'ac_lite_general_settings_section',
                 array( __( '<br>In compliance with GDPR, add a message on the Shop & Product pages to inform Registered users of how their data is being used.<br><i>For example: Please check our Privacy Policy to see how we use your personal data.</i>', 'woocommerce-abandoned-cart' ) )
             );
-            
+
             /**
              * New section for the Adding the abandoned cart setting.
              * @since  4.7
              */
-            
+
             add_settings_section(
             'ac_email_settings_section',                                                       // ID used to identify this section and with which to register options
             __( 'Settings for abandoned cart recovery emails', 'woocommerce-abandoned-cart' ), // Title to be displayed on the administration page
             array( $this, 'wcal_email_callback' ),                                             // Callback used to render the description of the section
             'woocommerce_ac_email_page'                                                        // Page on which to add this section of options
             );
-            
+
             add_settings_field(
             'wcal_from_name',
             __( '"From" Name', 'woocommerce-abandoned-cart'  ),
@@ -581,7 +581,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             'ac_email_settings_section',
             array( 'Enter the name that should appear in the email sent.', 'woocommerce-abandoned-cart' )
             );
-            
+
             add_settings_field(
             'wcal_from_email',
             __( '"From" Address', 'woocommerce-abandoned-cart'  ),
@@ -590,7 +590,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             'ac_email_settings_section',
             array( 'Email address from which the reminder emails should be sent.', 'woocommerce-abandoned-cart' )
             );
-            
+
             add_settings_field(
             'wcal_reply_email',
             __( 'Send Reply Emails to', 'woocommerce-abandoned-cart'  ),
@@ -599,7 +599,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             'ac_email_settings_section',
             array( 'When a contact receives your email and clicks reply, which email address should that reply be sent to?', 'woocommerce-abandoned-cart' )
             );
-            
+
             // Finally, we register the fields with WordPress
             register_setting(
                 'woocommerce_ac_settings',
@@ -612,12 +612,12 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                 'ac_lite_delete_abandoned_order_days',
                 array ( $this, 'wcal_delete_days_validation' )
             );
-            
+
             register_setting(
                 'woocommerce_ac_settings',
                 'ac_lite_email_admin_on_recovery'
             );
-             
+
             register_setting(
                 'woocommerce_ac_settings',
                 'ac_lite_track_guest_cart_from_cart_page'
@@ -627,12 +627,12 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                 'woocommerce_ac_settings',
                 'wcal_guest_cart_capture_msg'
             );
-            
+
             register_setting(
                 'woocommerce_ac_settings',
                 'wcal_logged_cart_capture_msg'
             );
-            
+
             register_setting(
                 'woocommerce_ac_email_settings',
                 'wcal_from_name'
@@ -648,15 +648,15 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
 
             do_action ( "wcal_add_new_settings" );
         }
-    
+
         /**
          * Settings API callback for section "ac_lite_general_settings_section".
          * @since 2.5
          */
         function ac_lite_general_options_callback() {
-        
+
         }
-    
+
         /**
          * Settings API callback for cart time field.
          * @param array $args Arguments
@@ -675,7 +675,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             $html = '<label for="ac_lite_cart_abandoned_time"> '  . $args[0] . '</label>';
             echo $html;
         }
-    
+
         /**
          * Settings API cart time field validation.
          * @param int | string $input
@@ -726,20 +726,20 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             $html = '<label for="ac_lite_delete_abandoned_order_days"> ' . $args[0] . '</label>';
             echo $html;
         }
-        
+
         /**
          * Settings API callback for email admin on cart recovery field.
          * @param array $args Arguments
          * @since 2.5
          */
-        function ac_lite_email_admin_on_recovery( $args ) {     
+        function ac_lite_email_admin_on_recovery( $args ) {
             // First, we read the option
             $email_admin_on_recovery = get_option( 'ac_lite_email_admin_on_recovery' );
-             
+
             // This condition added to avoid the notie displyed while Check box is unchecked.
             if ( isset( $email_admin_on_recovery ) && '' == $email_admin_on_recovery ) {
                 $email_admin_on_recovery = 'off';
-            }            
+            }
             // Next, we update the name attribute to access this element's ID in the context of the display options array
             // We also access the show_header element of the options collection in the call to the checked() helper function
             $html='';
@@ -747,7 +747,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             '<input type="checkbox" id="ac_lite_email_admin_on_recovery" name="ac_lite_email_admin_on_recovery" value="on"
             ' . checked('on', $email_admin_on_recovery, false).' />'
             );
-             
+
             // Here, we'll take the first argument of the array and add it to a label next to the checkbox
             $html .= '<label for="ac_lite_email_admin_on_recovery"> ' . $args[0] . '</label>';
             echo $html;
@@ -760,7 +760,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
         function wcal_track_guest_cart_from_cart_page_callback( $args ) {
             // First, we read the option
             $disable_guest_cart_from_cart_page = get_option( 'ac_lite_track_guest_cart_from_cart_page' );
-           
+
             // This condition added to avoid the notice displyed while Check box is unchecked.
             if ( isset( $disable_guest_cart_from_cart_page ) && '' == $disable_guest_cart_from_cart_page ) {
                 $disable_guest_cart_from_cart_page = 'off';
@@ -768,7 +768,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             // Next, we update the name attribute to access this element's ID in the context of the display options array
             // We also access the show_header element of the options collection in the call to the checked() helper function
             $html     = '';
-            
+
             printf(
             '<input type="checkbox" id="ac_lite_track_guest_cart_from_cart_page" name="ac_lite_track_guest_cart_from_cart_page" value="on"
                 '.checked( 'on', $disable_guest_cart_from_cart_page, false ) . ' />' );
@@ -776,33 +776,33 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             $html .= '<label for="ac_lite_track_guest_cart_from_cart_page"> ' . $args[0] . '</label>';
             echo $html;
         }
-        
+
         /**
          * Call back function for guest user cart capture message
          * @param array $args Argument for adding field details
          * @since 7.8
          */
         public static function wcal_guest_cart_capture_msg_callback( $args ) {
-        
+
             $guest_msg = get_option( 'wcal_guest_cart_capture_msg' );
-        
+
             $html = "<textarea rows='4' cols='80' id='wcal_guest_cart_capture_msg' name='wcal_guest_cart_capture_msg'>$guest_msg</textarea>";
-        
+
             $html .= '<label for="wcal_guest_cart_capture_msg"> ' . $args[0] . '</label>';
             echo $html;
         }
-        
+
         /**
          * Call back function for registered user cart capture message
          * @param array $args Argument for adding field details
          * @since 7.8
          */
         public static function wcal_logged_cart_capture_msg_callback( $args ) {
-        
+
             $logged_msg = get_option( 'wcal_logged_cart_capture_msg' );
-        
+
             $html = "<input type='text' class='regular-text' id='wcal_logged_cart_capture_msg' name='wcal_logged_cart_capture_msg' value='$logged_msg' />";
-        
+
             $html .= '<label for="wcal_logged_cart_capture_msg"> ' . $args[0] . '</label>';
             echo $html;
         }
@@ -812,9 +812,9 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
          * @since 3.5
          */
         function wcal_email_callback () {
-        
+
         }
-        
+
         /**
          * Settings API callback for from name used in Abandoned cart email.
          * @param array $args Arguments
@@ -833,7 +833,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             $html = '<label for="wcal_from_name_label"> '  . $args[0] . '</label>';
             echo $html;
         }
-        
+
         /**
          * Settings API callback for from email used in Abandoned cart email.
          * @param array $args Arguments
@@ -852,7 +852,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             $html = '<label for="wcal_from_email_label"> '  . $args[0] . '</label>';
             echo $html;
         }
-        
+
         /**
          * Settings API callback for reply email used in Abandoned cart email.
          * @param array $args Arguments
@@ -880,7 +880,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
          */
         function wcal_update_db_check() {
             global $wpdb;
-            
+
             $wcal_previous_version = get_option( 'wcal_previous_version' );
 
             if ( $wcal_previous_version != wcal_common::wcal_get_version() ) {
@@ -890,7 +890,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             /**
              * This is used to prevent guest users wrong Id. If guest users id is less then 63000000 then this code will
              * ensure that we will change the id of guest tables so it wont affect on the next guest users.
-             */         
+             */
             if ( $wpdb->get_var( "SHOW TABLES LIKE '{$wpdb->prefix}ac_guest_abandoned_cart_history_lite';" )  && 'yes' != get_option( 'wcal_guest_user_id_altered' ) ) {
                 $last_id = $wpdb->get_var( "SELECT max(id) FROM `{$wpdb->prefix}ac_guest_abandoned_cart_history_lite`;" );
                 if ( NULL != $last_id && $last_id <= 63000000 ) {
@@ -899,37 +899,37 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                 }
             }
 
-            if( !get_option( 'wcal_new_default_templates' ) ) {          
+            if( !get_option( 'wcal_new_default_templates' ) ) {
                     $default_template = new wcal_default_template_settings;
                     $default_template->wcal_create_default_templates();
                     add_option( 'wcal_new_default_templates', "yes" );
-                
+
             }
             if ( 'yes' != get_option( 'ac_lite_alter_table_queries' ) ) {
                 $ac_history_table_name = $wpdb->prefix."ac_abandoned_cart_history_lite";
                 $check_table_query     = "SHOW COLUMNS FROM $ac_history_table_name LIKE 'user_type'";
                 $results               = $wpdb->get_results( $check_table_query );
-                
+
                 if ( 0 == count( $results ) ) {
                     $alter_table_query = "ALTER TABLE $ac_history_table_name ADD `user_type` text AFTER  `recovered_cart`";
                     $wpdb->get_results( $alter_table_query );
                 }
-        
+
                 $table_name                 = $wpdb->prefix . "ac_email_templates_lite";
                 $check_template_table_query = "SHOW COLUMNS FROM $table_name LIKE 'is_wc_template' ";
                 $results                    = $wpdb->get_results( $check_template_table_query );
-                 
+
                 if ( 0 == count( $results ) ) {
                     $alter_template_table_query = "ALTER TABLE $table_name
                     ADD COLUMN `is_wc_template` enum('0','1') COLLATE utf8_unicode_ci NOT NULL AFTER `template_name`,
                     ADD COLUMN `default_template` int(11) NOT NULL AFTER `is_wc_template`";
                     $wpdb->get_results( $alter_template_table_query );
                 }
-                
+
                 $table_name                       = $wpdb->prefix . "ac_email_templates_lite";
                 $check_email_template_table_query = "SHOW COLUMNS FROM $table_name LIKE 'wc_email_header' ";
                 $results_email                    = $wpdb->get_results( $check_email_template_table_query );
-                
+
                 if ( 0 == count( $results_email ) ) {
                     $alter_email_template_table_query = "ALTER TABLE $table_name
                     ADD COLUMN `wc_email_header` varchar(50) NOT NULL AFTER `default_template`";
@@ -941,16 +941,16 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                         $wpdb->query( "ALTER TABLE {$wpdb->prefix}ac_abandoned_cart_history_lite ADD `unsubscribe_link` enum('0','1') COLLATE utf8_unicode_ci NOT NULL AFTER `user_type`;" );
                     }
                 }
-            
+
                 if ( $wpdb->get_var( "SHOW TABLES LIKE '{$wpdb->prefix}ac_abandoned_cart_history_lite';" ) ) {
                     if ( ! $wpdb->get_var( "SHOW COLUMNS FROM `{$wpdb->prefix}ac_abandoned_cart_history_lite` LIKE 'session_id';" ) ) {
                         $wpdb->query( "ALTER TABLE {$wpdb->prefix}ac_abandoned_cart_history_lite ADD `session_id` varchar(50) COLLATE utf8_unicode_ci NOT NULL AFTER `unsubscribe_link`;" );
                     }
-                }           
-                
+                }
+
                 /**
                  * We have moved email templates fields in the setings section. SO to remove that fields column fro the db we need it.
-                 * For existing user we need to fill this setting with the first template. 
+                 * For existing user we need to fill this setting with the first template.
                  * @since 4.7
                  */
                 if ( $wpdb->get_var( "SHOW TABLES LIKE '{$wpdb->prefix}ac_email_templates_lite';" ) ) {
@@ -959,53 +959,53 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                         $get_email_template_result = $wpdb->get_results ( $get_email_template_query );
                         $wcal_from_email = '';
                         if ( isset( $get_email_template_result ) && count ( $get_email_template_result ) > 0 ){
-                            $wcal_from_email =  $get_email_template_result[0]->from_email;          
+                            $wcal_from_email =  $get_email_template_result[0]->from_email;
                             /* Store data in setings api*/
-                            update_option ( 'wcal_from_email', $wcal_from_email );          
+                            update_option ( 'wcal_from_email', $wcal_from_email );
                             /* Delete table from the Db*/
                             $wpdb->query( "ALTER TABLE {$wpdb->prefix}ac_email_templates_lite DROP COLUMN `from_email`;" );
                         }
                     }
-                
+
                     if ( $wpdb->get_var( "SHOW COLUMNS FROM `{$wpdb->prefix}ac_email_templates_lite` LIKE 'from_name';" ) ) {
                         $get_email_template_from_name_query  = "SELECT `from_name` FROM {$wpdb->prefix}ac_email_templates_lite WHERE `is_active` = '1' ORDER BY `id` ASC LIMIT 1";
                         $get_email_template_from_name_result = $wpdb->get_results ( $get_email_template_from_name_query );
                         $wcal_from_name = '';
                         if ( isset( $get_email_template_from_name_result ) && count ( $get_email_template_from_name_result ) > 0 ){
-                            $wcal_from_name =  $get_email_template_from_name_result[0]->from_name;          
+                            $wcal_from_name =  $get_email_template_from_name_result[0]->from_name;
                             /* Store data in setings api*/
-                            add_option ( 'wcal_from_name', $wcal_from_name );           
+                            add_option ( 'wcal_from_name', $wcal_from_name );
                             /* Delete table from the Db*/
                             $wpdb->query( "ALTER TABLE {$wpdb->prefix}ac_email_templates_lite DROP COLUMN `from_name`;" );
                         }
                     }
-                
+
                     if ( $wpdb->get_var( "SHOW COLUMNS FROM `{$wpdb->prefix}ac_email_templates_lite` LIKE 'reply_email';" ) ) {
                         $get_email_template_reply_email_query  = "SELECT `reply_email` FROM {$wpdb->prefix}ac_email_templates_lite WHERE `is_active` = '1' ORDER BY `id` ASC LIMIT 1";
                         $get_email_template_reply_email_result = $wpdb->get_results ( $get_email_template_reply_email_query);
                         $wcal_reply_email = '';
                         if ( isset( $get_email_template_reply_email_result ) && count ( $get_email_template_reply_email_result ) > 0 ){
-                            $wcal_reply_email =  $get_email_template_reply_email_result[0]->reply_email;            
+                            $wcal_reply_email =  $get_email_template_reply_email_result[0]->reply_email;
                             /* Store data in setings api*/
-                            update_option ( 'wcal_reply_email', $wcal_reply_email );            
+                            update_option ( 'wcal_reply_email', $wcal_reply_email );
                             /* Delete table from the Db*/
                             $wpdb->query( "ALTER TABLE {$wpdb->prefix}ac_email_templates_lite DROP COLUMN `reply_email`;" );
                         }
                     }
                 }
- 
+
                 if ( ! get_option( 'wcal_security_key' ) ) {
                     update_option( 'wcal_security_key', 'qJB0rGtIn5UB1xG03efyCp' );
                 }
 
                 update_option( 'ac_lite_alter_table_queries', 'yes' );
             }
-            
+
             //get the option, if it is not set to individual then convert to individual records and delete the base record
-            $ac_settings = get_option( 'ac_lite_settings_status' );     
+            $ac_settings = get_option( 'ac_lite_settings_status' );
             if ( 'INDIVIDUAL' != $ac_settings ) {
                 //fetch the existing settings and save them as inidividual to be used for the settings API
-                $woocommerce_ac_settings = json_decode( get_option( 'woocommerce_ac_settings' ) ); 
+                $woocommerce_ac_settings = json_decode( get_option( 'woocommerce_ac_settings' ) );
 
                 if ( isset( $woocommerce_ac_settings[0]->cart_time ) ) {
                     add_option( 'ac_lite_cart_abandoned_time', $woocommerce_ac_settings[0]->cart_time );
@@ -1018,7 +1018,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                 } else {
                     add_option( 'ac_lite_delete_abandoned_order_days', "" );
                 }
-            
+
                 if ( isset( $woocommerce_ac_settings[0]->email_admin ) ) {
                     add_option( 'ac_lite_email_admin_on_recovery', $woocommerce_ac_settings[0]->email_admin );
                 } else {
@@ -1045,7 +1045,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             }
 
             if ( 'yes' !== get_option( 'ac_lite_user_cleanup' ) ) {
-                $query_cleanup = "UPDATE `".$wpdb->prefix."ac_guest_abandoned_cart_history_lite` SET 
+                $query_cleanup = "UPDATE `".$wpdb->prefix."ac_guest_abandoned_cart_history_lite` SET
                     billing_first_name = IF (billing_first_name LIKE '%<%', '', billing_first_name),
                     billing_last_name = IF (billing_last_name LIKE '%<%', '', billing_last_name),
                     billing_company_name = IF (billing_company_name LIKE '%<%', '', billing_company_name),
@@ -1084,24 +1084,24 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                 update_option( 'ac_lite_remove_abandoned_data', 'yes' );
             }
         }
-         
+
         /**
          * Add a submenu page under the WooCommerce.
          * @hook admin_menu
          * @since 1.0
-         */ 
+         */
         function wcal_admin_menu() {
             $page = add_submenu_page ( 'woocommerce', __( 'Abandoned Carts', 'woocommerce-abandoned-cart' ), __( 'Abandoned Carts', 'woocommerce-abandoned-cart' ), 'manage_woocommerce', 'woocommerce_ac_page', array( &$this, 'wcal_menu_page' ) );
         }
-            
+
         /**
          * Capture the cart and insert the information of the cart into DataBase.
          * @hook woocommerce_cart_updated
          * @globals mixed $wpdb
          * @globals mixed $woocommerce
          * @since 1.0
-         */ 
-        function wcal_store_cart_timestamp() {  
+         */
+        function wcal_store_cart_timestamp() {
 
             if ( get_transient( 'wcal_email_sent_id' ) !== false ) {
                 wcal_common::wcal_set_cart_session( 'email_sent_id', get_transient( 'wcal_email_sent_id' ) );
@@ -1114,24 +1114,24 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
 
             global $wpdb,$woocommerce;
             $current_time                    = current_time( 'timestamp' );
-            $cut_off_time                    = get_option( 'ac_lite_cart_abandoned_time' );              
+            $cut_off_time                    = get_option( 'ac_lite_cart_abandoned_time' );
             $track_guest_cart_from_cart_page = get_option( 'ac_lite_track_guest_cart_from_cart_page' );
             $cart_ignored                    = 0;
-            $recovered_cart                  = 0;  
+            $recovered_cart                  = 0;
 
-            $track_guest_user_cart_from_cart = "";          
+            $track_guest_user_cart_from_cart = "";
             if ( isset( $track_guest_cart_from_cart_page ) ) {
                 $track_guest_user_cart_from_cart = $track_guest_cart_from_cart_page;
             }
-            
+
             if ( isset( $cut_off_time ) ) {
                 $cart_cut_off_time = intval( $cut_off_time ) * 60;
             } else {
                 $cart_cut_off_time = 60 * 60;
-            }           
+            }
             $compare_time = $current_time - $cart_cut_off_time;
-            
-            if ( is_user_logged_in() ) {    
+
+            if ( is_user_logged_in() ) {
                 $user_id = get_current_user_id();
                 $query   = "SELECT * FROM `".$wpdb->prefix."ac_abandoned_cart_history_lite`
                             WHERE user_id      = %d
@@ -1156,7 +1156,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                         wcal_common::wcal_set_cart_session( 'abandoned_cart_id_lite', $abandoned_cart_id );
                     }
                 } elseif ( isset( $results[0]->abandoned_cart_time ) && $compare_time > $results[0]->abandoned_cart_time ) {
-                    $wcal_woocommerce_persistent_cart = version_compare( $woocommerce->version, '3.1.0', ">=" ) ? '_woocommerce_persistent_cart_' . get_current_blog_id() : '_woocommerce_persistent_cart' ; 
+                    $wcal_woocommerce_persistent_cart = version_compare( $woocommerce->version, '3.1.0', ">=" ) ? '_woocommerce_persistent_cart_' . get_current_blog_id() : '_woocommerce_persistent_cart' ;
                     $updated_cart_info                = json_encode( get_user_meta( $user_id, $wcal_woocommerce_persistent_cart, true ) );
 
                     if ( ! $this->wcal_compare_carts( $user_id, $results[0]->abandoned_cart_info ) ) {
@@ -1165,18 +1165,18 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                           SET cart_ignored = %s
                                           WHERE user_id    = %d ";
                         $wpdb->query( $wpdb->prepare( $query_ignored, $updated_cart_ignored, $user_id ) );
-                        
+
                         $user_type    = "REGISTERED";
                         $query_update = "INSERT INTO `".$wpdb->prefix."ac_abandoned_cart_history_lite`
                                          (user_id, abandoned_cart_info, abandoned_cart_time, cart_ignored, user_type)
                                          VALUES (%d, %s, %d, %s, %s)";
                         $wpdb->query( $wpdb->prepare( $query_update, $user_id, $updated_cart_info, $current_time, $cart_ignored, $user_type ) );
-                        
+
                         update_user_meta ( $user_id, '_woocommerce_ac_modified_cart', md5( "yes" ) );
-                        
-                        $abandoned_cart_id                  = $wpdb->insert_id;                     
+
+                        $abandoned_cart_id                  = $wpdb->insert_id;
                         wcal_common::wcal_set_cart_session( 'abandoned_cart_id_lite', $abandoned_cart_id );
-                    } else {    
+                    } else {
                         update_user_meta ( $user_id, '_woocommerce_ac_modified_cart', md5( "no" ) );
                     }
                 } else {
@@ -1186,11 +1186,11 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                     $query_update = "UPDATE `".$wpdb->prefix."ac_abandoned_cart_history_lite`
                                      SET abandoned_cart_info = %s,
                                          abandoned_cart_time = %d
-                                     WHERE user_id      = %d 
+                                     WHERE user_id      = %d
                                      AND   cart_ignored = %s ";
                     $wpdb->query( $wpdb->prepare( $query_update, $updated_cart_info, $current_time, $user_id, $cart_ignored ) );
-                    
-                    $query_update = "SELECT * FROM `" . $wpdb->prefix . "ac_abandoned_cart_history_lite` WHERE user_id ='" . $user_id . "' AND cart_ignored='0' ";                   
+
+                    $query_update = "SELECT * FROM `" . $wpdb->prefix . "ac_abandoned_cart_history_lite` WHERE user_id ='" . $user_id . "' AND cart_ignored='0' ";
                     $get_abandoned_record = $wpdb->get_results( $query_update );
 
                     if ( count( $get_abandoned_record ) > 0 ) {
@@ -1198,7 +1198,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                         wcal_common::wcal_set_cart_session( 'abandoned_cart_id_lite', $abandoned_cart_id );
                     }
                 }
-            } else { 
+            } else {
                 //start here guest user
                 $user_id = wcal_common::wcal_get_cart_session( 'user_id' );
 
@@ -1216,62 +1216,62 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                 $updated_cart_info = json_encode( $cart );
                 //$updated_cart_info = addslashes ( $updated_cart_info );
 
-                if ( count( $results ) > 0 && '{"cart":[]}' != $updated_cart_info ) {                    
+                if ( count( $results ) > 0 && '{"cart":[]}' != $updated_cart_info ) {
                     if ( $compare_time > $results[0]->abandoned_cart_time ) {
                         if ( ! $this->wcal_compare_only_guest_carts( $updated_cart_info, $results[0]->abandoned_cart_info ) ) {
 
-                            $query_ignored = "UPDATE `".$wpdb->prefix."ac_abandoned_cart_history_lite` 
-                                             SET cart_ignored = '1' 
+                            $query_ignored = "UPDATE `".$wpdb->prefix."ac_abandoned_cart_history_lite`
+                                             SET cart_ignored = '1'
                                              WHERE user_id ='".$user_id."'";
                             $wpdb->query( $query_ignored );
 
-                            $user_type    = 'GUEST';                
+                            $user_type    = 'GUEST';
                             $query_update = "INSERT INTO `".$wpdb->prefix."ac_abandoned_cart_history_lite`
                                      (user_id, abandoned_cart_info, abandoned_cart_time, cart_ignored, user_type)
                                      VALUES (%d, %s, %d, %s, %s)";
-                            $wpdb->query( $wpdb->prepare( $query_update, $user_id, $updated_cart_info, $current_time, $cart_ignored, $user_type ) );                                                                       
-                            update_user_meta( $user_id, '_woocommerce_ac_modified_cart', md5("yes") );     
+                            $wpdb->query( $wpdb->prepare( $query_update, $user_id, $updated_cart_info, $current_time, $cart_ignored, $user_type ) );
+                            update_user_meta( $user_id, '_woocommerce_ac_modified_cart', md5("yes") );
                         } else {
                             update_user_meta( $user_id, '_woocommerce_ac_modified_cart', md5("no") );
-                        }  
+                        }
                     } else {
-                        $query_update = "UPDATE `".$wpdb->prefix."ac_abandoned_cart_history_lite` 
-                                         SET abandoned_cart_info = '".$updated_cart_info."', abandoned_cart_time = '".$current_time."' 
+                        $query_update = "UPDATE `".$wpdb->prefix."ac_abandoned_cart_history_lite`
+                                         SET abandoned_cart_info = '".$updated_cart_info."', abandoned_cart_time = '".$current_time."'
                                          WHERE user_id='".$user_id."' AND cart_ignored='0' ";
                         $wpdb->query( $query_update );
                     }
-                } else {                   
+                } else {
                     /**
                      * Here we capture the guest cart from the cart page.
                      * @since 3.5
-                     */                  
-                    if ( 'on' == $track_guest_user_cart_from_cart && '' != $get_cookie[0] ) {                    
+                     */
+                    if ( 'on' == $track_guest_user_cart_from_cart && '' != $get_cookie[0] ) {
                         $query   = "SELECT * FROM `" . $wpdb->prefix . "ac_abandoned_cart_history_lite` WHERE session_id LIKE %s AND cart_ignored = '0' AND recovered_cart = '0' ";
-                        $results = $wpdb->get_results( $wpdb->prepare( $query, $get_cookie[0] ) ); 
-                        if ( 0 == count( $results ) ) {                        
+                        $results = $wpdb->get_results( $wpdb->prepare( $query, $get_cookie[0] ) );
+                        if ( 0 == count( $results ) ) {
                             $cart_info       = $updated_cart_info;
-                            $blank_cart_info = '[]';                        
+                            $blank_cart_info = '[]';
                             if ( $blank_cart_info != $cart_info && '{"cart":[]}' != $cart_info ) {
                                 $insert_query = "INSERT INTO `" . $wpdb->prefix . "ac_abandoned_cart_history_lite`
                                                 ( abandoned_cart_info , abandoned_cart_time , cart_ignored , recovered_cart, user_type, session_id  )
                                                 VALUES ( '" . $cart_info."' , '" . $current_time . "' , '0' , '0' , 'GUEST', '". $get_cookie[0] ."' )";
                                 $wpdb->query( $insert_query );
-                            }                        
-                        } elseif ( $compare_time > $results[0]->abandoned_cart_time ) {                        
-                            $blank_cart_info = '[]';                                
-                            if ( $blank_cart_info != $updated_cart_info && '{"cart":[]}' != $updated_cart_info ) { 
+                            }
+                        } elseif ( $compare_time > $results[0]->abandoned_cart_time ) {
+                            $blank_cart_info = '[]';
+                            if ( $blank_cart_info != $updated_cart_info && '{"cart":[]}' != $updated_cart_info ) {
                                 if ( ! $this->wcal_compare_only_guest_carts( $updated_cart_info, $results[0]->abandoned_cart_info ) ) {
                                     $query_ignored = "UPDATE `" . $wpdb->prefix . "ac_abandoned_cart_history_lite` SET cart_ignored = '1' WHERE session_id ='" . $get_cookie[0] . "'";
                                     $wpdb->query( $query_ignored );
                                     $query_update = "INSERT INTO `" . $wpdb->prefix . "ac_abandoned_cart_history_lite`
                                                     ( abandoned_cart_info, abandoned_cart_time, cart_ignored, recovered_cart, user_type, session_id )
                                                     VALUES ( '" . $updated_cart_info . "', '" . $current_time . "', '0', '0', 'GUEST', '". $get_cookie[0] ."' )";
-                                    $wpdb->query( $query_update );                                    
+                                    $wpdb->query( $query_update );
                                 }
                             }
-                        } else {                        
-                            $blank_cart_info = '[]';                        
-                            if ( $blank_cart_info != $updated_cart_info && '{"cart":[]}' != $updated_cart_info ) {                        
+                        } else {
+                            $blank_cart_info = '[]';
+                            if ( $blank_cart_info != $updated_cart_info && '{"cart":[]}' != $updated_cart_info ) {
                                 if ( ! $this->wcal_compare_only_guest_carts( $updated_cart_info, $results[0]->abandoned_cart_info ) ) {
                                     $query_update = "UPDATE `" . $wpdb->prefix . "ac_abandoned_cart_history_lite` SET abandoned_cart_info = '" . $updated_cart_info . "', abandoned_cart_time  = '" . $current_time . "' WHERE session_id ='" . $get_cookie[0] . "' AND cart_ignored='0' ";
                                     $wpdb->query( $query_update );
@@ -1279,10 +1279,10 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                             }
                         }
                     }
-                }                               
+                }
             }
         }
-       
+
         /**
          * It will unsubscribe the abandoned cart, so user will not recieve further abandoned cart emails.
          * @hook template_include
@@ -1293,29 +1293,29 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
          */
         function wcal_email_unsubscribe( $args ) {
             global $wpdb;
-            
+
             if ( isset( $_GET['wcal_track_unsubscribe'] ) && $_GET['wcal_track_unsubscribe'] == 'wcal_unsubscribe' ) {
                 $encoded_email_id              = rawurldecode( $_GET['validate'] );
                 $validate_email_id_string      = str_replace( " " , "+", $encoded_email_id );
                 $validate_email_address_string = '';
                 $validate_email_id_decode      = 0;
                 $cryptKey                      = get_option( 'wcal_security_key' );
-                $validate_email_id_decode      = Wcal_Aes_Ctr::decrypt( $validate_email_id_string, $cryptKey, 256 );        
+                $validate_email_id_decode      = Wcal_Aes_Ctr::decrypt( $validate_email_id_string, $cryptKey, 256 );
                 if ( isset( $_GET['track_email_id'] ) ) {
                     $encoded_email_address         = rawurldecode( $_GET['track_email_id'] );
                     $validate_email_address_string = str_replace( " " , "+", $encoded_email_address );
                 }
                 $query_id      = "SELECT * FROM `" . $wpdb->prefix . "ac_sent_history_lite` WHERE id = %d ";
                 $results_sent  = $wpdb->get_results ( $wpdb->prepare( $query_id, $validate_email_id_decode ) );
-                $email_address = '';        
+                $email_address = '';
                 if ( isset( $results_sent[0] ) ) {
                     $email_address =  $results_sent[0]->sent_email_id;
-                }        
-                if ( $validate_email_address_string == hash( 'sha256', $email_address ) && '' != $email_address ) {  
+                }
+                if ( $validate_email_address_string == hash( 'sha256', $email_address ) && '' != $email_address ) {
                     $email_sent_id     = $validate_email_id_decode;
                     $get_ac_id_query   = "SELECT abandoned_order_id FROM `" . $wpdb->prefix . "ac_sent_history_lite` WHERE id = %d";
                     $get_ac_id_results = $wpdb->get_results( $wpdb->prepare( $get_ac_id_query , $email_sent_id ) );
-                    $user_id           = 0;                    
+                    $user_id           = 0;
                     if ( isset( $get_ac_id_results[0] ) ) {
                         $get_user_id_query = "SELECT user_id FROM `" . $wpdb->prefix . "ac_abandoned_cart_history_lite` WHERE id = %d";
                         $get_user_results  = $wpdb->get_results( $wpdb->prepare( $get_user_id_query , $get_ac_id_results[0]->abandoned_order_id ) );
@@ -1323,11 +1323,11 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                     if ( isset( $get_user_results[0] ) ) {
                         $user_id = $get_user_results[0]->user_id;
                     }
-                     
+
                     $unsubscribe_query = "UPDATE `" . $wpdb->prefix . "ac_abandoned_cart_history_lite`
-                                            SET unsubscribe_link = '1' 
+                                            SET unsubscribe_link = '1'
                                             WHERE user_id= %d AND cart_ignored='0' ";
-                    $wpdb->query( $wpdb->prepare( $unsubscribe_query , $user_id ) ); 
+                    $wpdb->query( $wpdb->prepare( $unsubscribe_query , $user_id ) );
                     echo "Unsubscribed Successfully";
                     sleep( 2 );
                     $url = get_option( 'siteurl' );
@@ -1335,41 +1335,41 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                    <script>
                         location.href = "<?php echo $url; ?>";
                    </script>
-                   <?php 
+                   <?php
                 }
             } else {
-               return $args; 
+               return $args;
             }
         }
-    
+
         /**
          * It will track the URL of cart link from email, and it will populate the logged-in and guest users cart.
          * @hook template_include
-         * @param string $template 
+         * @param string $template
          * @return string $template
          * @globals mixed $wpdb
          * @globals mixed $woocommerce
          * @since 1.0
-         */ 
-        function wcal_email_track_links( $template ) {              
+         */
+        function wcal_email_track_links( $template ) {
             global $woocommerce;
             $track_link = '';
-        
-            if ( isset( $_GET['wcal_action'] ) ) {                  
+
+            if ( isset( $_GET['wcal_action'] ) ) {
                 $track_link = $_GET['wcal_action'];
-            }       
+            }
             if ( $track_link == 'track_links' ) {
                 if ( '' === session_id() ) {
                     //session has not started
                     session_start();
-                }            
+                }
                 global $wpdb;
                 $validate_server_string  = rawurldecode( $_GET ['validate'] );
                 $validate_server_string  = str_replace( " " , "+", $validate_server_string );
-                $validate_encoded_string = $validate_server_string;       
+                $validate_encoded_string = $validate_server_string;
                 $cryptKey                = get_option( 'wcal_security_key' );
-                $link_decode             = Wcal_Aes_Ctr::decrypt( $validate_encoded_string, $cryptKey, 256 );                          
-                $sent_email_id_pos       = strpos( $link_decode, '&' );               
+                $link_decode             = Wcal_Aes_Ctr::decrypt( $validate_encoded_string, $cryptKey, 256 );
+                $sent_email_id_pos       = strpos( $link_decode, '&' );
                 $email_sent_id           = substr( $link_decode , 0, $sent_email_id_pos );
 
                 wcal_common::wcal_set_cart_session( 'email_sent_id', $email_sent_id );
@@ -1377,7 +1377,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
 
                 $url_pos                 = strpos( $link_decode, '=' );
                 $url_pos                 = $url_pos + 1;
-                $url                     = substr( $link_decode, $url_pos );             
+                $url                     = substr( $link_decode, $url_pos );
                 $get_ac_id_query         = "SELECT abandoned_order_id FROM `".$wpdb->prefix."ac_sent_history_lite` WHERE id = %d";
                 $get_ac_id_results       = $wpdb->get_results( $wpdb->prepare( $get_ac_id_query, $email_sent_id ) );
 
@@ -1389,20 +1389,20 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                     $get_user_id_query = "SELECT user_id FROM `".$wpdb->prefix."ac_abandoned_cart_history_lite` WHERE id = %d";
                     $get_user_results  = $wpdb->get_results( $wpdb->prepare( $get_user_id_query, $get_ac_id_results[0]->abandoned_order_id ) );
                 }
-                $user_id = 0;     
-                if ( isset( $get_user_results ) && count( $get_user_results ) > 0 ) { 
+                $user_id = 0;
+                if ( isset( $get_user_results ) && count( $get_user_results ) > 0 ) {
                     $user_id = $get_user_results[0]->user_id;
-                }               
+                }
                 if ( 0 == $user_id ) {
                     echo "Link expired";
                     exit;
-                }               
-                $user = wp_set_current_user( $user_id );                
+                }
+                $user = wp_set_current_user( $user_id );
                 if ( $user_id >= "63000000" ) {
                     $query_guest   = "SELECT * from `". $wpdb->prefix."ac_guest_abandoned_cart_history_lite` WHERE id = %d";
                     $results_guest = $wpdb->get_results( $wpdb->prepare( $query_guest, $user_id ) );
                     $query_cart    = "SELECT recovered_cart FROM `".$wpdb->prefix."ac_abandoned_cart_history_lite` WHERE user_id = %d";
-                    $results       = $wpdb->get_results( $wpdb->prepare( $query_cart, $user_id ) );                 
+                    $results       = $wpdb->get_results( $wpdb->prepare( $query_cart, $user_id ) );
                     if ( $results_guest  && $results[0]->recovered_cart == '0' ) {
                         wcal_common::wcal_set_cart_session( 'guest_first_name', $results_guest[0]->billing_first_name );
                         wcal_common::wcal_set_cart_session( 'guest_last_name', $results_guest[0]->billing_last_name );
@@ -1418,33 +1418,33 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                         }
                     }
                 }
-        
+
                 if ( $user_id < "63000000" ) {
                     $user_login = $user->data->user_login;
                     wp_set_auth_cookie( $user_id );
                     $my_temp    = wc_load_persistent_cart( $user_login, $user );
-                    do_action( 'wp_login', $user_login, $user );        
+                    do_action( 'wp_login', $user_login, $user );
                     if ( isset( $sign_in ) && is_wp_error( $sign_in ) ) {
                         echo $sign_in->get_error_message();
                         exit;
                     }
-                } else  
+                } else
                     $my_temp = $this->wcal_load_guest_persistent_cart( $user_id );
-                   
-                if ( $email_sent_id > 0 && is_numeric( $email_sent_id ) ) {                     
+
+                if ( $email_sent_id > 0 && is_numeric( $email_sent_id ) ) {
                     header( "Location: $url" );
                 }
             } else
                 return $template;
         }
-    
+
         /**
-         * When customer clicks on the abandoned cart link and that cart is for the the guest users the it will load the guest 
+         * When customer clicks on the abandoned cart link and that cart is for the the guest users the it will load the guest
          * user's cart detail.
          * @globals mixed $woocommerce
          * @since 1.0
-         */   
-        function wcal_load_guest_persistent_cart() {                
+         */
+        function wcal_load_guest_persistent_cart() {
             if ( wcal_common::wcal_get_cart_session( 'user_id' ) != '' ) {
                 global $woocommerce;
                 $saved_cart = json_decode( get_user_meta( wcal_common::wcal_get_cart_session( 'user_id' ), '_woocommerce_persistent_cart',true ), true );
@@ -1452,7 +1452,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                 $cart_contents_total = $cart_contents_weight = $cart_contents_count = $cart_contents_tax = $total = $subtotal = $subtotal_ex_tax = $tax_total = 0;
                 if ( count( $saved_cart ) > 0 ) {
                     foreach ( $saved_cart as $key => $value ) {
-                        foreach ( $value as $a => $b ) {  
+                        foreach ( $value as $a => $b ) {
                             $c['product_id']        = $b['product_id'];
                             $c['variation_id']      = $b['variation_id'];
                             $c['variation']         = $b['variation'];
@@ -1474,9 +1474,9 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                         $woocommerce_cart_hash      = $a;
                     }
                 }
-            
+
                 if ( $saved_cart ) {
-                    if ( empty( $woocommerce->session->cart ) || ! is_array( $woocommerce->session->cart ) || sizeof( $woocommerce->session->cart ) == 0 ) {    
+                    if ( empty( $woocommerce->session->cart ) || ! is_array( $woocommerce->session->cart ) || sizeof( $woocommerce->session->cart ) == 0 ) {
                         $woocommerce->session->cart                 = $saved_cart['cart'];
                         $woocommerce->session->cart_contents_total  = $cart_contents_total;
                         $woocommerce->session->cart_contents_weight = $cart_contents_weight;
@@ -1502,7 +1502,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                 }
             }
         }
-        
+
         /**
          * It will compare only guest users cart while capturing the cart.
          * @param json_encode $new_cart New abandoned cart details
@@ -1512,11 +1512,11 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
          */
         function wcal_compare_only_guest_carts( $new_cart, $last_abandoned_cart ) {
             $current_woo_cart   = array();
-            $current_woo_cart   = json_decode( stripslashes( $new_cart ), true );   
+            $current_woo_cart   = json_decode( stripslashes( $new_cart ), true );
             $abandoned_cart_arr = array();
             $abandoned_cart_arr = json_decode( $last_abandoned_cart, true );
             $temp_variable      = "";
-            if ( isset( $current_woo_cart['cart'] ) && isset( $abandoned_cart_arr['cart'] ) ) {                 
+            if ( isset( $current_woo_cart['cart'] ) && isset( $abandoned_cart_arr['cart'] ) ) {
                 if ( count( $current_woo_cart['cart'] ) >= count( $abandoned_cart_arr['cart'] ) ) {
                     //do nothing
                 } else {
@@ -1530,7 +1530,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                             $current_cart_product_id   = $item_value['product_id'];
                             $current_cart_variation_id = $item_value['variation_id'];
                             $current_cart_quantity     = $item_value['quantity'];
-            
+
                             if ( isset( $abandoned_cart_arr[$key][$item_key]['product_id'] ) ){
                                 $abandoned_cart_product_id = $abandoned_cart_arr[$key][$item_key]['product_id'];
                             } else {
@@ -1554,7 +1554,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                         }
                     }
                 }
-            }    
+            }
             return true;
         }
 
@@ -1565,15 +1565,15 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
          * @return boolean true | false
          * @since 1.0
          */
-        function wcal_compare_carts( $user_id, $last_abandoned_cart ) { 
+        function wcal_compare_carts( $user_id, $last_abandoned_cart ) {
             global $woocommerce;
             $current_woo_cart   = array();
             $abandoned_cart_arr = array();
-            $wcal_woocommerce_persistent_cart =version_compare( $woocommerce->version, '3.1.0', ">=" ) ? '_woocommerce_persistent_cart_' . get_current_blog_id() : '_woocommerce_persistent_cart' ;         
+            $wcal_woocommerce_persistent_cart =version_compare( $woocommerce->version, '3.1.0', ">=" ) ? '_woocommerce_persistent_cart_' . get_current_blog_id() : '_woocommerce_persistent_cart' ;
             $current_woo_cart   = get_user_meta( $user_id, $wcal_woocommerce_persistent_cart, true );
             $abandoned_cart_arr = json_decode( $last_abandoned_cart, true );
             $temp_variable      = "";
-            if ( isset( $current_woo_cart['cart'] ) && isset( $abandoned_cart_arr['cart'] ) ) {        
+            if ( isset( $current_woo_cart['cart'] ) && isset( $abandoned_cart_arr['cart'] ) ) {
                 if ( count( $current_woo_cart['cart'] ) >= count( $abandoned_cart_arr['cart'] ) ) {
                     //do nothing
                 } else {
@@ -1583,19 +1583,19 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                 }
                 if ( is_array( $current_woo_cart ) && is_array( $abandoned_cart_arr ) ) {
                     foreach ( $current_woo_cart as $key => $value ) {
-                        
+
                         foreach ( $value as $item_key => $item_value ) {
                             $current_cart_product_id   = $item_value['product_id'];
                             $current_cart_variation_id = $item_value['variation_id'];
                             $current_cart_quantity     = $item_value['quantity'];
-            
+
                             if ( isset( $abandoned_cart_arr[$key][$item_key]['product_id'] ) ) {
                                 $abandoned_cart_product_id = $abandoned_cart_arr[$key][$item_key]['product_id'];
                             } else {
                                 $abandoned_cart_product_id = "";
                             }
                             if ( isset( $abandoned_cart_arr[$key][$item_key]['variation_id'] ) ) {
-                                 $abandoned_cart_variation_id = $abandoned_cart_arr[$key][$item_key]['variation_id']; 
+                                 $abandoned_cart_variation_id = $abandoned_cart_arr[$key][$item_key]['variation_id'];
                             } else {
                                 $abandoned_cart_variation_id = "";
                             }
@@ -1613,7 +1613,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                         }
                     }
                 }
-            }    
+            }
             return true;
         }
 
@@ -1631,7 +1631,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             }
             if ( ! current_user_can( 'edit_posts' ) && ! current_user_can( 'edit_pages' ) ) {
                 return;
-            }           
+            }
             if ( 'true' == get_user_option( 'rich_editing' ) ) {
                 remove_filter( 'the_excerpt', 'wpautop' );
                 add_filter( 'tiny_mce_before_init',  array( &$this, 'wcal_format_tiny_MCE' ) );
@@ -1639,11 +1639,11 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                 add_filter( 'mce_external_plugins',  array( &$this, 'wcal_filter_mce_plugin' ) );
             }
         }
-        
+
         /**
          * It will create a button on the WordPress editor.
          * @hook mce_buttons
-         * @param array $buttons 
+         * @param array $buttons
          * @return array $buttons
          * @since 2.6
          */
@@ -1652,11 +1652,11 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             array_push( $buttons, 'abandoncart', '|' );
             return $buttons;
         }
-        
+
         /**
          * It will add the list for the added extra button.
          * @hook mce_external_plugins
-         * @param array $plugins 
+         * @param array $plugins
          * @return array $plugins
          * @since 2.6
          */
@@ -1665,25 +1665,25 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             $plugins['abandoncart'] = plugin_dir_url( __FILE__ ) . 'assets/js/abandoncart_plugin_button.js';
             return $plugins;
         }
-        
+
         /**
          * It will add the tabs on the Abandoned cart page.
          * @since 1.0
          */
         function wcal_display_tabs() {
-        
+
             if ( isset( $_GET['action'] ) ) {
                 $action = $_GET['action'];
             } else {
-                $action                = "";            
+                $action                = "";
                 $active_listcart       = "";
                 $active_emailtemplates = "";
                 $active_settings       = "";
                 $active_stats          = "";
-            }           
+            }
             if ( ( 'listcart' == $action || 'orderdetails' == $action ) || '' == $action ) {
                 $active_listcart = "nav-tab-active";
-            }           
+            }
             if ( 'emailtemplates' == $action ) {
                 $active_emailtemplates = "nav-tab-active";
             }
@@ -1695,10 +1695,10 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             }
             if ( 'report' == $action ) {
                 $active_report = "nav-tab-active";
-            }       
-            ?>          
+            }
+            ?>
             <div style="background-image: url('<?php echo plugins_url(); ?>/woocommerce-abandoned-cart/assets/images/ac_tab_icon.png') !important;" class="icon32"><br>
-            </div>                      
+            </div>
             <h2 class="nav-tab-wrapper woo-nav-tab-wrapper">
                 <a href="admin.php?page=woocommerce_ac_page&action=listcart" class="nav-tab <?php if ( isset( $active_listcart ) ) echo $active_listcart; ?>"> <?php _e( 'Abandoned Orders', 'woocommerce-abandoned-cart' );?> </a>
                 <a href="admin.php?page=woocommerce_ac_page&action=emailtemplates" class="nav-tab <?php if ( isset( $active_emailtemplates ) ) echo $active_emailtemplates; ?>"> <?php _e( 'Email Templates', 'woocommerce-abandoned-cart' );?> </a>
@@ -1710,7 +1710,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             </h2>
             <?php
         }
-        
+
         /**
          * It will add the scripts needed for the plugin.
          * @hook admin_enqueue_scripts
@@ -1723,7 +1723,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
 
             if (  $page === '' || $page !== 'woocommerce_ac_page' ) {
                 return;
-            } else {                
+            } else {
                 wp_enqueue_script( 'jquery' );
                 wp_enqueue_script(
                     'jquery-ui-min',
@@ -1741,13 +1741,13 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                    false
                 );
 
-                
+
                 wp_register_script( 'woocommerce_admin', plugins_url() . '/woocommerce/assets/js/admin/woocommerce_admin.min.js', array( 'jquery', 'jquery-tiptip' ) );
                     wp_register_script( 'woocommerce_tip_tap', plugins_url() . '/woocommerce/assets/js/jquery-tiptip/jquery.tipTip.min.js', array( 'jquery') );
                     wp_enqueue_script( 'woocommerce_tip_tap');
                     wp_enqueue_script( 'woocommerce_admin');
                     $locale  = localeconv();
-                    $decimal = isset( $locale['decimal_point'] ) ? $locale['decimal_point'] : '.';         
+                    $decimal = isset( $locale['decimal_point'] ) ? $locale['decimal_point'] : '.';
                     $params  = array(
                         /* translators: %s: decimal */
                         'i18n_decimal_error'                => sprintf( __( 'Please enter in decimal (%s) format without thousand separators.', 'woocommerce' ), $decimal ),
@@ -1773,19 +1773,19 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                      */
                     wp_localize_script( 'woocommerce_admin', 'woocommerce_admin', $params );
                 ?>
-                <script type="text/javascript" >                
+                <script type="text/javascript" >
                     function wcal_activate_email_template( template_id, active_state ) {
                         location.href = 'admin.php?page=woocommerce_ac_page&action=emailtemplates&mode=activate_template&id='+template_id+'&active_state='+active_state ;
                     }
                 </script>
-                <?php 
-                $js_src = includes_url('js/tinymce/') . 'tinymce.min.js'; 
+                <?php
+                $js_src = includes_url('js/tinymce/') . 'tinymce.min.js';
                 wp_enqueue_script( 'tinyMce_ac',$js_src );
-                wp_enqueue_script( 'ac_email_variables', plugins_url() . '/woocommerce-abandoned-cart/assets/js/abandoncart_plugin_button.js' ); 
-                wp_enqueue_script( 'wcal_activate_template', plugins_url() . '/woocommerce-abandoned-cart/assets/js/wcal_template_activate.js' ); 
+                wp_enqueue_script( 'ac_email_variables', plugins_url() . '/woocommerce-abandoned-cart/assets/js/abandoncart_plugin_button.js' );
+                wp_enqueue_script( 'wcal_activate_template', plugins_url() . '/woocommerce-abandoned-cart/assets/js/wcal_template_activate.js' );
             }
         }
-        
+
         /**
          * It will add the parameter to the editor.
          * @hook tiny_mce_before_init
@@ -1793,7 +1793,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
          * @return array $in
          * @since 2.6
          */
-        function wcal_format_tiny_MCE( $in ) {      
+        function wcal_format_tiny_MCE( $in ) {
             $in['force_root_block']             = false;
             $in['valid_children']               = '+body[style]';
             $in['remove_linebreaks']            = false;
@@ -1810,14 +1810,14 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             $in['wpautop']                      = false;
             $in['apply_source_formatting']      = true;
             $in['cleanup']                      = true;
-            $in['convert_newlines_to_brs']      = FALSE; 
-            $in['fullpage_default_xml_pi']      = false; 
+            $in['convert_newlines_to_brs']      = FALSE;
+            $in['fullpage_default_xml_pi']      = false;
             $in['convert_urls']                 = false;
             // Do not remove redundant BR tags
-            $in['remove_redundant_brs']         = false; 
+            $in['remove_redundant_brs']         = false;
             return $in;
         }
-        
+
         /**
          * It will add the necesaary css for the plugin.
          * @hook admin_enqueue_scripts
@@ -1833,48 +1833,48 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             if ( $page != 'woocommerce_ac_page' ) {
                 return;
             } elseif ( $page === 'woocommerce_ac_page' ) {
-                
-                wp_enqueue_style( 'jquery-ui',                plugins_url() . '/woocommerce-abandoned-cart/assets/css/jquery-ui.css', '', '', false );               
+
+                wp_enqueue_style( 'jquery-ui',                plugins_url() . '/woocommerce-abandoned-cart/assets/css/jquery-ui.css', '', '', false );
                 wp_enqueue_style( 'woocommerce_admin_styles', plugins_url() . '/woocommerce/assets/css/admin.css' );
-                
+
                 wp_enqueue_style( 'jquery-ui-style',          plugins_url() . '/woocommerce-abandoned-cart/assets/css/jquery-ui-smoothness.css' );
                 wp_enqueue_style( 'abandoned-orders-list', plugins_url() . '/woocommerce-abandoned-cart/assets/css/view.abandoned.orders.style.css' );
                 wp_enqueue_style( 'wcal_email_template', plugins_url() . '/woocommerce-abandoned-cart/assets/css/wcal_template_activate.css' );
-            
+
             }
-        }       
-       
+        }
+
 
         /**
-         * When we have added the wp list table for the listing then while deleting the record with the bulk action it was showing 
-         * the notice. To overcome the wp redirect warning we need to start the ob_start. 
+         * When we have added the wp list table for the listing then while deleting the record with the bulk action it was showing
+         * the notice. To overcome the wp redirect warning we need to start the ob_start.
          * @hook init
          * @since 2.5.2
          */
         function wcal_app_output_buffer() {
             ob_start();
         }
-            
+
         /**
          * Abandon Cart Settings Page. It will show the tabs, notices for the plugin.
-         * It will also update the template records and display the template fields. 
+         * It will also update the template records and display the template fields.
          * It will also show the abandoned cart details page.
          * It will also show the details of all the tabs.
          * @globals mixed $wpdb
          * @since 1.0
          */
         function wcal_menu_page() {
-            
+
             if ( is_user_logged_in() ) {
-                global $wpdb;                   
+                global $wpdb;
                 // Check the user capabilities
-                if ( ! current_user_can( 'manage_woocommerce' ) ) {    
+                if ( ! current_user_can( 'manage_woocommerce' ) ) {
                     wp_die( __( 'You do not have sufficient permissions to access this page.', 'woocommerce-abandoned-cart' ) );
-                }           
+                }
                 ?>
-                <div class="wrap">    
+                <div class="wrap">
                     <h2><?php _e( 'WooCommerce - Abandon Cart Lite', 'woocommerce-abandoned-cart' ); ?></h2>
-                <?php 
+                <?php
 
                 if ( isset( $_GET['ac_update'] ) && 'email_templates' === $_GET['ac_update'] ) {
                     $status = wcal_common::update_templates_table();
@@ -1885,7 +1885,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                         wcal_common::show_update_failure();
                     }
                 }
-            
+
                 if ( isset( $_GET['action'] ) ) {
                     $action = $_GET['action'];
                 } else {
@@ -1895,11 +1895,11 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                     $mode = $_GET['mode'];
                 } else {
                     $mode = "";
-                }                                          
+                }
                 $this->wcal_display_tabs();
-                
+
                 do_action ( 'wcal_add_tab_content' );
-                
+
                 /**
                  * When we delete the item from the below drop down it is registred in action 2
                 */
@@ -1930,27 +1930,27 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                     $class->wcal_delete_template_bulk_action_handler_function( $id );
                     }
                 }
-             
+
                 if ( isset( $_GET['wcal_deleted'] ) && 'YES' == $_GET['wcal_deleted'] ) { ?>
                      <div id="message" class="updated fade">
                        <p><strong><?php _e( 'The Abandoned cart has been successfully deleted.', 'woocommerce-abandoned-cart' ); ?></strong></p>
                      </div>
-                <?php }    
+                <?php }
                  if ( isset( $_GET ['wcal_template_deleted'] ) && 'YES' == $_GET['wcal_template_deleted'] ) { ?>
                     <div id="message" class="updated fade">
                         <p><strong><?php _e( 'The Template has been successfully deleted.', 'woocommerce-abandoned-cart' ); ?></strong></p>
                     </div>
-                <?php }            
+                <?php }
                  if ( 'emailsettings' == $action ) {
                  // Save the field values
                     ?>
                     <p><?php _e( 'Change settings for sending email notifications to Customers, to Admin etc.', 'woocommerce-abandoned-cart' ); ?></p>
                     <div id="content">
-                    <?php 
+                    <?php
                         $wcal_general_settings_class = $wcal_email_setting = $wcap_sms_settings = $wcap_atc_settings = $wcap_fb_settings = "";
 
                         $section = isset( $_GET[ 'wcal_section' ] ) ? $_GET[ 'wcal_section' ] : '';
-                        
+
                         switch( $section ) {
 
                             case 'wcal_general_settings':
@@ -1978,7 +1978,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                 $wcal_general_settings_class = "current";
                                 break;
 
-                        }                     
+                        }
 ?>
                         <ul class="subsubsub" id="wcal_general_settings_list">
                             <li>
@@ -1991,11 +1991,11 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                 <a href="admin.php?page=woocommerce_ac_page&action=emailsettings&wcal_section=wcap_atc_settings" class="<?php echo $wcap_atc_settings; ?>"><?php _e( 'Add To Cart Popup Editor', 'woocommerce-ac' );?> </a> |
                             </li>
                             <li>
-                                <a href="admin.php?page=woocommerce_ac_page&action=emailsettings&wcal_section=wcap_fb_settings" class="<?php echo $wcap_fb_settings; ?>"><?php _e( 'Facebook Messenger', 'woocommerce-ac' );?> </a> | 
+                                <a href="admin.php?page=woocommerce_ac_page&action=emailsettings&wcal_section=wcap_fb_settings" class="<?php echo $wcap_fb_settings; ?>"><?php _e( 'Facebook Messenger', 'woocommerce-ac' );?> </a> |
                             </li>
                             <li>
-                                <a href="admin.php?page=woocommerce_ac_page&action=emailsettings&wcal_section=wcap_sms_settings" class="<?php echo $wcap_sms_settings; ?>"><?php _e( 'SMS', 'woocommerce-ac' );?> </a> 
-                            </li>                    
+                                <a href="admin.php?page=woocommerce_ac_page&action=emailsettings&wcal_section=wcap_sms_settings" class="<?php echo $wcap_sms_settings; ?>"><?php _e( 'SMS', 'woocommerce-ac' );?> </a>
+                            </li>
 
                         </ul>
                         <br class="clear">
@@ -2006,9 +2006,9 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                 <?php settings_fields( 'woocommerce_ac_settings' ); ?>
                                 <?php do_settings_sections( 'woocommerce_ac_page' ); ?>
                                 <?php settings_errors(); ?>
-                                <?php submit_button(); ?>    
+                                <?php submit_button(); ?>
                             </form>
-                        <?php 
+                        <?php
                         } else if ( 'wcal_email_settings' == $section ) {
                         ?>
                             <form method="post" action="options.php">
@@ -2017,7 +2017,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                 <?php settings_errors(); ?>
                                 <?php submit_button(); ?>
                             </form>
-                          <?php 
+                          <?php
                         } elseif( 'wcap_atc_settings' == $section ) {
                             WCAP_Pro_Settings::wcap_atc_settings();
                         } elseif( 'wcap_fb_settings' == $section ) {
@@ -2027,26 +2027,26 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                         }
                         ?>
                     </div>
-                  <?php 
+                  <?php
                   } elseif ( $action == 'listcart' || '' == $action || '-1' == $action || '-1' == $action_two ) {
-                        ?>    
+                        ?>
                         <p> <?php _e( 'The list below shows all Abandoned Carts which have remained in cart for a time higher than the "Cart abandoned cut-off time" setting.', 'woocommerce-abandoned-cart' );?> </p>
                         <?php
                         $get_all_abandoned_count      = wcal_common::wcal_get_abandoned_order_count( 'wcal_all_abandoned' );
                         $get_registered_user_ac_count = wcal_common::wcal_get_abandoned_order_count( 'wcal_all_registered' );
                         $get_guest_user_ac_count      = wcal_common::wcal_get_abandoned_order_count( 'wcal_all_guest' );
-                        $get_visitor_user_ac_count    = wcal_common::wcal_get_abandoned_order_count( 'wcal_all_visitor' );                      
-                        
+                        $get_visitor_user_ac_count    = wcal_common::wcal_get_abandoned_order_count( 'wcal_all_visitor' );
+
                         $wcal_user_reg_text = 'User';
                         if ( $get_registered_user_ac_count > 1 ) {
                             $wcal_user_reg_text = 'Users';
-                        }                    
+                        }
                         $wcal_user_gus_text = 'User';
                         if ( $get_guest_user_ac_count > 1 ) {
                             $wcal_user_gus_text = 'Users';
-                        }                                                                    
+                        }
                         $wcal_all_abandoned_carts  = $section = $wcal_all_registered = $wcal_all_guest = $wcal_all_visitor = "" ;
-                        
+
                         if ( isset( $_GET[ 'wcal_section' ] ) ) {
                             $section = $_GET[ 'wcal_section' ];
                         } else {
@@ -2055,7 +2055,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                         if ( 'wcal_all_abandoned' == $section || '' == $section ) {
                             $wcal_all_abandoned_carts = "current";
                         }
-                        
+
                         if ( 'wcal_all_registered' == $section ) {
                             $wcal_all_registered      = "current";
                             $wcal_all_abandoned_carts = "";
@@ -2064,7 +2064,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                             $wcal_all_guest           = "current";
                             $wcal_all_abandoned_carts = "";
                         }
-                        
+
                         if ( 'wcal_all_visitor' == $section ) {
                             $wcal_all_visitor         = "current";
                             $wcal_all_abandoned_carts = "";
@@ -2072,29 +2072,29 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                         ?>
                         <ul class="subsubsub" id="wcal_recovered_orders_list">
                             <li>
-                                <a href="admin.php?page=woocommerce_ac_page&action=listcart&wcal_section=wcal_all_abandoned" class="<?php echo $wcal_all_abandoned_carts; ?>"><?php _e( "All ", 'woocommerce-abandoned-cart' ) ;?> <span class = "count" > <?php echo "( $get_all_abandoned_count )" ?> </span></a> 
+                                <a href="admin.php?page=woocommerce_ac_page&action=listcart&wcal_section=wcal_all_abandoned" class="<?php echo $wcal_all_abandoned_carts; ?>"><?php _e( "All ", 'woocommerce-abandoned-cart' ) ;?> <span class = "count" > <?php echo "( $get_all_abandoned_count )" ?> </span></a>
                             </li>
-    
+
                             <?php if ( $get_registered_user_ac_count > 0 ) { ?>
                             <li>
-                                | <a href="admin.php?page=woocommerce_ac_page&action=listcart&wcal_section=wcal_all_registered" class="<?php echo $wcal_all_registered; ?>"><?php printf( __( 'Registered %s', 'woocommerce-abandoned-cart' ), $wcal_user_reg_text ); ?> <span class = "count" > <?php echo "( $get_registered_user_ac_count )" ?> </span></a> 
+                                | <a href="admin.php?page=woocommerce_ac_page&action=listcart&wcal_section=wcal_all_registered" class="<?php echo $wcal_all_registered; ?>"><?php printf( __( 'Registered %s', 'woocommerce-abandoned-cart' ), $wcal_user_reg_text ); ?> <span class = "count" > <?php echo "( $get_registered_user_ac_count )" ?> </span></a>
                             </li>
                             <?php } ?>
-    
+
                             <?php if ( $get_guest_user_ac_count > 0 ) { ?>
                             <li>
-                                | <a href="admin.php?page=woocommerce_ac_page&action=listcart&wcal_section=wcal_all_guest" class="<?php echo $wcal_all_guest; ?>"><?php printf( __( 'Guest %s', 'woocommerce-abandoned-cart' ), $wcal_user_gus_text ); ?> <span class = "count" > <?php echo "( $get_guest_user_ac_count )" ?> </span></a> 
+                                | <a href="admin.php?page=woocommerce_ac_page&action=listcart&wcal_section=wcal_all_guest" class="<?php echo $wcal_all_guest; ?>"><?php printf( __( 'Guest %s', 'woocommerce-abandoned-cart' ), $wcal_user_gus_text ); ?> <span class = "count" > <?php echo "( $get_guest_user_ac_count )" ?> </span></a>
                             </li>
                             <?php } ?>
-    
+
                             <?php if ( $get_visitor_user_ac_count > 0 ) { ?>
                             <li>
-                                | <a href="admin.php?page=woocommerce_ac_page&action=listcart&wcal_section=wcal_all_visitor" class="<?php echo $wcal_all_visitor; ?>"><?php _e( "Carts without Customer Details", 'woocommerce-abandoned-cart' ); ?> <span class = "count" > <?php echo "( $get_visitor_user_ac_count )" ?> </span></a> 
+                                | <a href="admin.php?page=woocommerce_ac_page&action=listcart&wcal_section=wcal_all_visitor" class="<?php echo $wcal_all_visitor; ?>"><?php _e( "Carts without Customer Details", 'woocommerce-abandoned-cart' ); ?> <span class = "count" > <?php echo "( $get_visitor_user_ac_count )" ?> </span></a>
                             </li>
                             <?php } ?>
                         </ul>
-                        
-                        <?php 
+
+                        <?php
                         global $wpdb;
                         include_once( 'includes/classes/class-wcal-abandoned-orders-table.php' );
                         $wcal_abandoned_order_list = new WCAL_Abandoned_Orders_Table();
@@ -2106,14 +2106,14 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                  <input type="hidden" name="action" value="listcart" />
                                 <?php $wcal_abandoned_order_list->display(); ?>
                             </form>
-                        </div>                        
-                        <?php 
+                        </div>
+                        <?php
                   } elseif ( ( 'emailtemplates' == $action && ( 'edittemplate' != $mode && 'addnewtemplate' != $mode ) || '' == $action || '-1' == $action || '-1' == $action_two ) ) {
                         ?>
                         <p> <?php _e( 'Add email templates at different intervals to maximize the possibility of recovering your abandoned carts.', 'woocommerce-abandoned-cart' );?> </p>
-                        <?php                       
+                        <?php
                         // Save the field values
-                        $insert_template_successfuly = $update_template_successfuly = ''; 
+                        $insert_template_successfuly = $update_template_successfuly = '';
                         if ( isset( $_POST['ac_settings_frm'] ) && 'save' == $_POST['ac_settings_frm'] ) {
                             $woocommerce_ac_email_subject = trim( htmlspecialchars( $_POST['woocommerce_ac_email_subject'] ), ENT_QUOTES );
                             $woocommerce_ac_email_body    = trim( $_POST['woocommerce_ac_email_body'] );
@@ -2124,11 +2124,11 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                             $day_or_hour                  = trim( $_POST['day_or_hour'] );
                             $is_wc_template               = ( empty( $_POST['is_wc_template'] ) ) ? '0' : '1';
                             $default_value                =  0 ;
-                            
+
                             $query = "INSERT INTO `".$wpdb->prefix."ac_email_templates_lite`
                                       (subject, body, frequency, day_or_hour, template_name, is_wc_template, default_template, wc_email_header )
                                       VALUES ( %s, %s, %d, %s, %s, %s, %d, %s )";
-                            
+
                             $insert_template_successfuly = $wpdb->query( $wpdb->prepare( $query,
                                                            $woocommerce_ac_email_subject,
                                                            $woocommerce_ac_email_body,
@@ -2137,35 +2137,35 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                                            $woocommerce_ac_template_name,
                                                            $is_wc_template,
                                                            $default_value,
-                                                           $woocommerce_ac_email_header )        
-                            );                                 
+                                                           $woocommerce_ac_email_header )
+                            );
                         }
-                        
-                        if ( isset( $_POST['ac_settings_frm'] ) && 'update' == $_POST['ac_settings_frm'] ) { 
-                             
+
+                        if ( isset( $_POST['ac_settings_frm'] ) && 'update' == $_POST['ac_settings_frm'] ) {
+
                             $updated_is_active            = '0';
-                            
+
                             $email_frequency              = trim( $_POST['email_frequency'] );
                             $day_or_hour                  = trim( $_POST['day_or_hour'] );
                             $is_wc_template               = ( empty( $_POST['is_wc_template'] ) ) ? '0' : '1';
-                            
+
                             $woocommerce_ac_email_subject = trim( htmlspecialchars( $_POST['woocommerce_ac_email_subject'] ), ENT_QUOTES );
                             $woocommerce_ac_email_body    = trim( $_POST['woocommerce_ac_email_body'] );
                             $woocommerce_ac_template_name = trim( $_POST['woocommerce_ac_template_name'] );
                             $woocommerce_ac_email_header  = stripslashes( trim( htmlspecialchars( $_POST['wcal_wc_email_header'] ), ENT_QUOTES ) );
                             $id                           = trim( $_POST['id'] );
-                            
+
                             $check_query = "SELECT * FROM `".$wpdb->prefix."ac_email_templates_lite`
                                             WHERE id = %d ";
                             $check_results = $wpdb->get_results( $wpdb->prepare( $check_query, $id ) );
                             $default_value = '';
 
-                            if ( count( $check_results ) > 0 ) { 
+                            if ( count( $check_results ) > 0 ) {
                                 if ( isset( $check_results[0]->default_template ) && $check_results[0]->default_template == '1' ) {
                                     $default_value = '1';
                                 }
                             }
-                            
+
                             $query_update_latest = "UPDATE `".$wpdb->prefix."ac_email_templates_lite`
                                                     SET
                                                     subject       = %s,
@@ -2177,7 +2177,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                                     default_template = %d,
                                                     wc_email_header = %s
                                                     WHERE id      = %d ";
-                                
+
                             $update_template_successfuly = $wpdb->query( $wpdb->prepare( $query_update_latest,
                                                             $woocommerce_ac_email_subject,
                                                             $woocommerce_ac_email_body,
@@ -2188,20 +2188,20 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                                             $default_value,
                                                             $woocommerce_ac_email_header,
                                                             $id )
-                            );   
-                            
+                            );
+
                         }
-                        
+
                         if ( 'emailtemplates' == $action && 'removetemplate' == $mode ) {
                             $id_remove = $_GET['id'];
                             $query_remove = "DELETE FROM `".$wpdb->prefix."ac_email_templates_lite` WHERE id= %d ";
                             $wpdb->query( $wpdb->prepare( $query_remove, $id_remove ) );
                         }
-                        
+
                         if ( 'emailtemplates' == $action && 'activate_template' == $mode ) {
                             $template_id             = $_GET['id'];
                             $current_template_status = $_GET['active_state'];
-                        
+
                             if ( "1" == $current_template_status ) {
                                 $active = "0";
                             } else {
@@ -2214,7 +2214,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                 $email_day_or_hour             = $get_selected_template_result[0]->day_or_hour;
 
                                 $query_update = "UPDATE `".$wpdb->prefix."ac_email_templates_lite` SET is_active='0' WHERE frequency='" . $email_frequncy . "' AND day_or_hour='" . $email_day_or_hour . "' ";
-                                $wcap_updated = $wpdb->query( $query_update );                              
+                                $wcap_updated = $wpdb->query( $query_update );
                             }
 
                             $query_update = "UPDATE `" . $wpdb->prefix . "ac_email_templates_lite`
@@ -2222,7 +2222,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                     is_active       = '" . $active . "'
                                     WHERE id        = '" . $template_id . "' ";
                             $wpdb->query( $query_update );
-                        
+
                             wp_safe_redirect( admin_url( '/admin.php?page=woocommerce_ac_page&action=emailtemplates' ) );
                         }
 
@@ -2243,7 +2243,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                         </strong>
                                     </p>
                                 </div>
-                             <?php   
+                             <?php
                         }
 
                         if ( isset( $_POST['ac_settings_frm'] ) && 'update' == $_POST['ac_settings_frm'] && isset( $update_template_successfuly ) && $update_template_successfuly !== false ) { ?>
@@ -2263,15 +2263,15 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                             </strong>
                                         </p>
                                     </div>
-                            <?php   
+                            <?php
                         }
                         ?>
                         <div class="tablenav">
                             <p style="float:left;">
                                <a cursor: pointer; href="<?php echo "admin.php?page=woocommerce_ac_page&action=emailtemplates&mode=addnewtemplate"; ?>" class="button-secondary"><?php _e( 'Add New Template', 'woocommerce-abandoned-cart' ); ?>
-                               </a>                           
+                               </a>
                             </p>
-                    
+
                             <?php
                             /* From here you can do whatever you want with the data from the $result link. */
                             include_once('includes/classes/class-wcal-templates-table.php');
@@ -2286,7 +2286,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                 </form>
                             </div>
                         </div>
-                        <?php 
+                        <?php
                    } elseif ( 'stats' == $action || '' == $action ) {
                         ?>
                         <p>
@@ -2319,32 +2319,32 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                         start_date = new Date( today.getFullYear(), today.getMonth(), today.getDate() - 365 );
                                         end_date   = new Date( today.getFullYear(), today.getMonth(), today.getDate() );
                                     }
-            
+
                                     var monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
                                                        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
-                                                   
+
                                     var start_date_value = start_date.getDate() + " " + monthNames[start_date.getMonth()] + " " + start_date.getFullYear();
                                     var end_date_value   = end_date.getDate() + " " + monthNames[end_date.getMonth()] + " " + end_date.getFullYear();
-            
+
                                     jQuery( '#start_date' ).val( start_date_value );
                                     jQuery( '#end_date' ).val( end_date_value );
                                } );
                             });
                         </script>
                         <?php
-                        
+
                         if ( isset( $_POST['duration_select'] ) ){
                                $duration_range = $_POST['duration_select'];
                         } else {
                                $duration_range = "";
-                        }       
+                        }
                         if ( '' == $duration_range ) {
                             if ( isset( $_GET['duration_select'] ) ){
                                 $duration_range = $_GET['duration_select'];
                             }
                         }
                         if ( '' == $duration_range ) $duration_range = "last_seven";
-                        
+
                             _e( 'The Report below shows how many Abandoned Carts we were able to recover for you by sending automatic emails to encourage shoppers.', 'woocommerce-abandoned-cart');
                         ?>
                         <div id="recovered_stats" class="postbox" style="display:block">
@@ -2356,9 +2356,9 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                             $sel = "";
                                             if ( $key == $duration_range ) {
                                                 $sel = " selected ";
-                                            } 
+                                            }
                                             echo"<option value='$key' $sel> $value </option>";
-                                        }                                       
+                                        }
                                         $date_sett = $this->start_end_dates[ $duration_range ];
                                         ?>
                                     </select>
@@ -2368,36 +2368,36 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                             var formats = ["d.m.y", "d M yy","MM d, yy"];
                                             jQuery( "#start_date" ).datepicker( { dateFormat: formats[1] } );
                                         });
-                        
+
                                         jQuery( document ).ready( function()
                                         {
                                             var formats = ["d.m.y", "d M yy","MM d, yy"];
                                             jQuery( "#end_date" ).datepicker( { dateFormat: formats[1] } );
                                         });
-                                    </script>                                                       
-                                    <?php 
-                                    include_once('includes/classes/class-wcal-recover-orders-table.php');                  
+                                    </script>
+                                    <?php
+                                    include_once('includes/classes/class-wcal-recover-orders-table.php');
                                     $wcal_recover_orders_list = new WCAL_Recover_Orders_Table();
                                     $wcal_recover_orders_list->wcal_recovered_orders_prepare_items();
-                                    
+
                                     if ( isset( $_POST['start_date'] ) ) $start_date_range = $_POST['start_date'];
                                     else $start_date_range = "";
-                    
+
                                     if ( $start_date_range == "" ) {
                                         $start_date_range = $date_sett['start_date'];
                                     }
-                    
+
                                     if ( isset( $_POST['end_date'] ) ) $end_date_range = $_POST['end_date'];
                                     else $end_date_range = "";
-                                    
+
                                     if ( $end_date_range == "" ) {
                                         $end_date_range = $date_sett['end_date'];
                                     }
-                                    ?>                       
+                                    ?>
                                     <label class="start_label" for="start_day"> <?php _e( 'Start Date:', 'woocommerce-abandoned-cart' ); ?> </label>
-                                    <input type="text" id="start_date" name="start_date" readonly="readonly" value="<?php echo $start_date_range; ?>"/>     
+                                    <input type="text" id="start_date" name="start_date" readonly="readonly" value="<?php echo $start_date_range; ?>"/>
                                     <label class="end_label" for="end_day"> <?php _e( 'End Date:', 'woocommerce-abandoned-cart' ); ?> </label>
-                                    <input type="text" id="end_date" name="end_date" readonly="readonly" value="<?php echo $end_date_range; ?>"/>  
+                                    <input type="text" id="end_date" name="end_date" readonly="readonly" value="<?php echo $end_date_range; ?>"/>
                                     <input type="submit" name="Submit" class="button-primary" value="<?php esc_attr_e( 'Go', 'woocommerce-abandoned-cart' ); ?>"  />
                                 </form>
                             </div>
@@ -2406,7 +2406,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                             <div class="inside" >
                                 <?php
                                 $count = $wcal_recover_orders_list->total_abandoned_cart_count;
-                                $total_of_all_order = $wcal_recover_orders_list->total_order_amount; 
+                                $total_of_all_order = $wcal_recover_orders_list->total_order_amount;
                                 $recovered_item = $wcal_recover_orders_list->recovered_item;
                                 $recovered_total = wc_price( $wcal_recover_orders_list->total_recover_amount );
                                 ?>
@@ -2440,16 +2440,16 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                         <th> <?php _e( 'Quantity', 'woocommerce-abandoned-cart' ); ?> </th>
                                         <th> <?php _e( 'Line Subtotal', 'woocommerce-abandoned-cart' ); ?> </th>
                                         <th> <?php _e( 'Line Total', 'woocommerce-abandoned-cart' ); ?> </th>
-                                    </tr>                                           
-                                    <?php 
+                                    </tr>
+                                    <?php
                                     $query = "SELECT * FROM `".$wpdb->prefix."ac_abandoned_cart_history_lite` WHERE id = %d ";
-                                    $results = $wpdb->get_results( $wpdb->prepare( $query,$_GET['id'] ) );                         
-                                    
+                                    $results = $wpdb->get_results( $wpdb->prepare( $query,$_GET['id'] ) );
+
                                     $shipping_charges = 0;
                                     $currency_symbol  = get_woocommerce_currency_symbol();
-                                    $number_decimal   = wc_get_price_decimals();                                    
+                                    $number_decimal   = wc_get_price_decimals();
                                     if ( $results[0]->user_type == "GUEST" && "0" != $results[0]->user_id ) {
-                                        $query_guest            = "SELECT * FROM `".$wpdb->prefix."ac_guest_abandoned_cart_history_lite` WHERE id = %d";  
+                                        $query_guest            = "SELECT * FROM `".$wpdb->prefix."ac_guest_abandoned_cart_history_lite` WHERE id = %d";
                                         $results_guest          = $wpdb->get_results( $wpdb->prepare( $query_guest, $results[0]->user_id ) );
                                         $user_email             = $user_first_name = $user_last_name = $user_billing_postcode = $user_shipping_postcode = '';
                                         $shipping_charges       = '';
@@ -2462,7 +2462,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                             $shipping_charges       = $results_guest[0]->shipping_charges;
                                         }
                                         $user_billing_company   = $user_billing_address_1 = $user_billing_address_2 = $user_billing_city = $user_billing_state = $user_billing_country  = $user_billing_phone = "";
-                                        $user_shipping_company  = $user_shipping_address_1 = $user_shipping_address_2 = $user_shipping_city = $user_shipping_state = $user_shipping_country = "";  
+                                        $user_shipping_company  = $user_shipping_address_1 = $user_shipping_address_2 = $user_shipping_city = $user_shipping_state = $user_shipping_country = "";
                                     } else if ( $results[0]->user_type == "GUEST" && $results[0]->user_id == "0" ) {
                                         $user_email             = '';
                                         $user_first_name        = "Visitor";
@@ -2472,13 +2472,13 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                         $shipping_charges       = '';
                                         $user_billing_phone     = '';
                                         $user_billing_company   = $user_billing_address_1 = $user_billing_address_2 = $user_billing_city = $user_billing_state = $user_billing_country  = "";
-                                        $user_shipping_company  = $user_shipping_address_1 = $user_shipping_address_2 = $user_shipping_city = $user_shipping_state = $user_shipping_country = "";                                       
+                                        $user_shipping_company  = $user_shipping_address_1 = $user_shipping_address_2 = $user_shipping_city = $user_shipping_state = $user_shipping_country = "";
                                     } else {
-                                        $user_id                = $results[0]->user_id;                                
+                                        $user_id                = $results[0]->user_id;
                                         if ( isset( $results[0]->user_login ) ) {
                                             $user_login         = $results[0]->user_login;
                                         }
-                                        $user_email             = get_user_meta( $results[0]->user_id, 'billing_email', true );                                        
+                                        $user_email             = get_user_meta( $results[0]->user_id, 'billing_email', true );
                                         if ( '' == $user_email ) {
                                             $user_data          = get_userdata( $results[0]->user_id );
                                             if ( isset( $user_data->user_email ) ) {
@@ -2487,7 +2487,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                                 $user_email = '';
                                             }
                                         }
-                                        
+
                                         $user_first_name      = "";
                                         $user_first_name_temp = get_user_meta( $user_id, 'billing_first_name', true );
                                         if ( isset( $user_first_name_temp ) && '' == $user_first_name_temp ) {
@@ -2499,7 +2499,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                             }
                                         } else {
                                             $user_first_name    = $user_first_name_temp;
-                                        }                                        
+                                        }
                                         $user_last_name         = "";
                                         $user_last_name_temp    = get_user_meta( $user_id, 'billing_last_name', true );
                                         if ( isset( $user_last_name_temp ) && "" == $user_last_name_temp ) {
@@ -2511,12 +2511,12 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                             }
                                         } else {
                                             $user_last_name = $user_last_name_temp;
-                                        }                                        
+                                        }
                                         $user_billing_first_name = get_user_meta( $results[0]->user_id, 'billing_first_name' );
-                                        $user_billing_last_name  = get_user_meta( $results[0]->user_id, 'billing_last_name' ); 
+                                        $user_billing_last_name  = get_user_meta( $results[0]->user_id, 'billing_last_name' );
 
                                         $user_billing_details    = wcal_common::wcal_get_billing_details( $results[0]->user_id );
-                    
+
                                         $user_billing_company    = $user_billing_details[ 'billing_company' ];
                                         $user_billing_address_1  = $user_billing_details[ 'billing_address_1' ];
                                         $user_billing_address_2  = $user_billing_details[ 'billing_address_2' ];
@@ -2530,48 +2530,48 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                             $user_billing_phone = $user_billing_phone_temp[0];
                                         } else {
                                             $user_billing_phone = "";
-                                        }                                        
+                                        }
                                         $user_shipping_first_name   = get_user_meta( $results[0]->user_id, 'shipping_first_name' );
-                                        $user_shipping_last_name    = get_user_meta( $results[0]->user_id, 'shipping_last_name' );                                        
-                                        $user_shipping_company_temp = get_user_meta( $results[0]->user_id, 'shipping_company' );                                        
+                                        $user_shipping_last_name    = get_user_meta( $results[0]->user_id, 'shipping_last_name' );
+                                        $user_shipping_company_temp = get_user_meta( $results[0]->user_id, 'shipping_company' );
                                         if ( isset( $user_shipping_company_temp[0] ) ) {
                                             $user_shipping_company  = $user_shipping_company_temp[0];
                                         } else {
                                             $user_shipping_company  = "";
-                                        }                                        
+                                        }
                                         $user_shipping_address_1_temp = get_user_meta( $results[0]->user_id, 'shipping_address_1' );
                                         if ( isset( $user_shipping_address_1_temp[0] ) ) {
                                             $user_shipping_address_1 = $user_shipping_address_1_temp[0];
                                         } else {
                                             $user_shipping_address_1 = "";
-                                        }                                        
+                                        }
                                         $user_shipping_address_2_temp = get_user_meta( $results[0]->user_id, 'shipping_address_2' );
                                         if ( isset( $user_shipping_address_2_temp[0] ) ) {
                                             $user_shipping_address_2 = $user_shipping_address_2_temp[0];
                                         } else {
                                             $user_shipping_address_2 = "";
-                                        }                                        
+                                        }
                                         $user_shipping_city_temp = get_user_meta( $results[0]->user_id, 'shipping_city' );
                                         if ( isset( $user_shipping_city_temp[0] ) ) {
                                             $user_shipping_city = $user_shipping_city_temp[0];
                                         } else {
                                             $user_shipping_city = "";
-                                        }                                        
+                                        }
                                         $user_shipping_postcode_temp = get_user_meta( $results[0]->user_id, 'shipping_postcode' );
                                         if ( isset( $user_shipping_postcode_temp[0] ) ) {
                                             $user_shipping_postcode = $user_shipping_postcode_temp[0];
                                         } else {
                                             $user_shipping_postcode = "";
-                                        }                                        
+                                        }
                                         $user_shipping_country_temp = get_user_meta( $results[0]->user_id, 'shipping_country' );
                                         $user_shipping_country = "";
                                         if ( isset( $user_shipping_country_temp[0] ) ) {
                                             $user_shipping_country = $user_shipping_country_temp[0];
                                             if ( isset( $woocommerce->countries->countries[ $user_shipping_country ] ) ) {
-                                        $user_shipping_country = $woocommerce->countries->countries[ $user_shipping_country ];    
+                                        $user_shipping_country = $woocommerce->countries->countries[ $user_shipping_country ];
                                             }else {
                                                 $user_shipping_country = "";
-                                            }                            
+                                            }
                                         }
                                         $user_shipping_state_temp = get_user_meta( $results[0]->user_id, 'shipping_state' );
                                         $user_shipping_state = "";
@@ -2580,16 +2580,16 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                             if ( isset( $woocommerce->countries->states[ $user_shipping_country_temp[0] ][ $user_shipping_state ] ) ) {
                                                 # code...
                                                 $user_shipping_state = $woocommerce->countries->states[ $user_shipping_country_temp[0] ][ $user_shipping_state ];
-                                            }    
-                                        }                  
-                                    } 
-                                    
+                                            }
+                                        }
+                                    }
+
                                     $cart_details   = array();
                                     $cart_info      = json_decode( $results[0]->abandoned_cart_info );
                                     $cart_details   = (array) $cart_info->cart;
                                     $item_subtotal  = $item_total = 0;
-                                    
-                                    if ( is_array ( $cart_details ) && count( $cart_details ) > 0 ) {                                                                              
+
+                                    if ( is_array ( $cart_details ) && count( $cart_details ) > 0 ) {
                                         foreach ( $cart_details as $k => $v ) {
 
                                             $item_details = wcal_common::wcal_get_cart_details( $v );
@@ -2605,26 +2605,26 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                             $item_subtotal  = $item_details[ 'item_total_formatted' ];
                                             $item_total     = $item_details[ 'item_total' ];
                                             $quantity_total = $item_details[ 'qty' ];
-                                            
+
                                             $qty_item_text = 'item';
                                             if ( $quantity_total > 1 ) {
                                                 $qty_item_text = 'items';
                                             }
-                                            ?>                   
+                                            ?>
                                         <tr>
                                             <td> <?php echo $prod_image; ?></td>
                                             <td> <?php echo '<a href="' . $product_page_url . '"> ' . $product_name . ' </a>'; ?> </td>
                                             <td> <?php echo $quantity_total; ?></td>
                                             <td> <?php echo $item_subtotal; ?></td>
                                             <td> <?php echo $item_total; ?></td>
-                                        </tr>           
-                                    <?php 
+                                        </tr>
+                                    <?php
                                     $item_subtotal = $item_total = 0;
                                         }
                                     }
                                   ?>
                                 </table>
-                            </div>  
+                            </div>
                         </div>
                         <div id="ac_order_customer_details" class="postbox" style="display:block">
                             <h3 class="details-title"> <p> <?php _e( 'Customer Details' , 'woocommerce-abandoned-cart' ); ?> </p> </h3>
@@ -2634,7 +2634,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                         <h3> <p> <?php _e( 'Billing Details' , 'woocommerce-abandoned-cart' ); ?> </p> </h3>
                                         <p> <strong> <?php _e( 'Name:' , 'woocommerce-abandoned-cart' ); ?> </strong>
                                             <?php echo $user_first_name." ".$user_last_name;?>
-                                        </p>                                    
+                                        </p>
                                         <p> <strong> <?php _e( 'Address:' , 'woocommerce-abandoned-cart' ); ?> </strong>
                                             <?php echo $user_billing_company."</br>".
                                                        $user_billing_address_1."</br>".
@@ -2643,20 +2643,20 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                                        $user_billing_postcode."</br>".
                                                        $user_billing_state."</br>".
                                                        $user_billing_country."</br>";
-                                                       ?> 
-                                        </p>                                        
+                                                       ?>
+                                        </p>
                                         <p> <strong> <?php _e( 'Email:', 'woocommerce-abandoned-cart' ); ?> </strong>
                                             <?php $user_mail_to =  "mailto:".$user_email; ?>
                                             <a href=<?php echo $user_mail_to;?>><?php echo $user_email;?> </a>
-                                        </p>                                            
+                                        </p>
                                         <p> <strong> <?php _e( 'Phone:', 'woocommerce-abandoned-cart' ); ?> </strong>
                                             <?php echo $user_billing_phone;?>
                                         </p>
-                                    </div>                                                                                   
+                                    </div>
                                     <div style="width:50%;float:right">
-                                        <h3> <p> <?php _e( 'Shipping Details', 'woocommerce-abandoned-cart' ); ?> </p> </h3>                                       
+                                        <h3> <p> <?php _e( 'Shipping Details', 'woocommerce-abandoned-cart' ); ?> </p> </h3>
                                         <p> <strong> <?php _e( 'Address:', 'woocommerce-abandoned-cart' ); ?> </strong>
-                                            <?php 
+                                            <?php
                                             if ( $user_shipping_company     == '' &&
                                                  $user_shipping_address_1   == '' &&
                                                  $user_shipping_address_2   == '' &&
@@ -2665,7 +2665,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                                  $user_shipping_state       == '' &&
                                                  $user_shipping_country     == '') {
                                                 echo "Shipping Address same as Billing Address";
-                                            } else { ?>                                
+                                            } else { ?>
                                             <?php echo $user_shipping_company."</br>".
                                                 $user_shipping_address_1."</br>".
                                                 $user_shipping_address_2."</br>".
@@ -2673,20 +2673,20 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                                 $user_shipping_postcode."</br>".
                                                 $user_shipping_state."</br>".
                                                 $user_shipping_country."</br>";
-                                            ?> 
+                                            ?>
                                                <br><br>
                                                <strong><?php _e( 'Shipping Charges', 'woocommerce-abandoned-lite' ); ?>: </strong>
                                                <?php if ( $shipping_charges != 0 ) echo $currency_symbol . $shipping_charges;?>
                                         </p>
-                                            <?php }?>                            
+                                            <?php }?>
                                     </div>
                                 </div>
                             </div>
-                        </div>                
+                        </div>
             <?php } elseif ( $action == 'report' ) {
                         include_once('includes/classes/class-wcal-product-report-table.php');
                         $wcal_product_report_list = new WCAL_Product_Report_Table();
-                        $wcal_product_report_list->wcal_product_report_prepare_items(); 
+                        $wcal_product_report_list->wcal_product_report_prepare_items();
                         ?>
                         <div class="wrap">
                             <form id="wcal-sent-emails" method="get" >
@@ -2694,27 +2694,27 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                 <input type="hidden" name="action" value="report" />
                                 <?php $wcal_product_report_list->display(); ?>
                             </form>
-                        </div>                           
+                        </div>
             <?php }
             }
             echo( "</table>" );
-                        
+
             if ( isset( $_GET['action'] ) ) {
                 $action = $_GET['action'];
-            }       
+            }
             if ( isset( $_GET['mode'] ) ) {
                 $mode = $_GET['mode'];
             }
-            if ( 'emailtemplates' == $action && ( 'addnewtemplate' == $mode || 'edittemplate' == $mode ) ) {                
+            if ( 'emailtemplates' == $action && ( 'addnewtemplate' == $mode || 'edittemplate' == $mode ) ) {
                 if ( 'edittemplate' == $mode ) {
                     $results = array();
-                    if ( isset( $_GET['id'] ) ) { 
+                    if ( isset( $_GET['id'] ) ) {
                         $edit_id = $_GET['id'];
                         $query   = "SELECT wpet . *  FROM `".$wpdb->prefix."ac_email_templates_lite` AS wpet WHERE id = %d ";
                         $results = $wpdb->get_results( $wpdb->prepare( $query, $edit_id ) );
                     }
                 }
-                $active_post = ( empty( $_POST['is_active'] ) ) ? '0' : '1';    
+                $active_post = ( empty( $_POST['is_active'] ) ) ? '0' : '1';
                 ?>
                 <div id="content">
                   <form method="post" action="admin.php?page=woocommerce_ac_page&action=emailtemplates" id="ac_settings">
@@ -2723,8 +2723,8 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                         $id_by = "";
                         if ( isset( $_GET['id'] ) ) {
                             $id_by = $_GET['id'];
-                        }       
-                        ?>                              
+                        }
+                        ?>
                         <input type="hidden" name="id" value="<?php echo $id_by ;?>" />
                         <?php
                         $button_mode     = "save";
@@ -2748,12 +2748,12 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                             $template_name = "";
                                             if ( 'edittemplate' == $mode && count( $results ) > 0 && isset( $results[0]->template_name ) ) {
                                                 $template_name = $results[0]->template_name;
-                                            }                                           
+                                            }
                                             print'<input type="text" name="woocommerce_ac_template_name" id="woocommerce_ac_template_name" class="regular-text" value="'.$template_name.'">';?>
                                             <img class="help_tip" width="16" height="16" data-tip='<?php _e('Enter a template name for reference', 'woocommerce-abandoned-cart') ?>' src="<?php echo plugins_url(); ?>/woocommerce/assets/images/help.png" />
                                         </td>
                                     </tr>
-                                    
+
                                     <tr>
                                        <th>
                                             <label for="woocommerce_ac_email_subject"><b><?php _e( 'Subject:', 'woocommerce-abandoned-cart' ); ?></b></label>
@@ -2763,7 +2763,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                             $subject_edit = "";
                                             if ( 'edittemplate' == $mode && count( $results ) > 0 && isset( $results[0]->subject ) ) {
                                                 $subject_edit= stripslashes ( $results[0]->subject );
-                                            }                                           
+                                            }
                                             print'<input type="text" name="woocommerce_ac_email_subject" id="woocommerce_ac_email_subject" class="regular-text" value="'.$subject_edit.'">';?>
                                             <img class="help_tip" width="16" height="16" data-tip='<?php _e('Enter the subject that should appear in the email sent', 'woocommerce-abandoned-cart') ?>' src="<?php echo plugins_url(); ?>/woocommerce/assets/images/help.png" />
                                         </td>
@@ -2773,14 +2773,14 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                         <th>
                                             <label for="woocommerce_ac_email_body"><b><?php _e( 'Email Body:', 'woocommerce-abandoned-cart' ); ?></b></label>
                                         </th>
-                                        <td>            
+                                        <td>
                                             <?php
                                             $initial_data = "";
                                             if ( 'edittemplate' == $mode && count( $results ) > 0 && isset( $results[0]->body ) ) {
                                                 $initial_data = stripslashes( $results[0]->body );
                                             }
-                                            
-                                            $initial_data = str_replace ( "My document title", "", $initial_data );                                         
+
+                                            $initial_data = str_replace ( "My document title", "", $initial_data );
                                             wp_editor(
                                                 $initial_data,
                                                 'woocommerce_ac_email_body',
@@ -2793,7 +2793,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                                     ),
                                                 )
                                             );
-                                            
+
                                             ?>
                                             <?php echo stripslashes( get_option( 'woocommerce_ac_email_body' ) ); ?>
                                             <span class="description">
@@ -2822,17 +2822,17 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                             }
                                         }
                                     </script>
-                                    
+
                                      <tr>
                                         <th>
                                             <label for="is_wc_template"><b><?php _e( 'Use WooCommerce Template Style:', 'woocommerce-abandoned-cart' ); ?></b></label>
                                         </th>
                                         <td>
                                             <?php
-                                            $is_wc_template = "";                                        
+                                            $is_wc_template = "";
                                             if ( 'edittemplate' == $mode && count( $results ) > 0 && isset( $results[0]->is_wc_template ) ) {
                                                 $use_wc_template = $results[0]->is_wc_template;
-                                                
+
                                                 if ( '1' == $use_wc_template ) {
                                                     $is_wc_template = "checked";
                                                 } else {
@@ -2840,11 +2840,11 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                                 }
                                             }
                                             print'<input type="checkbox" name="is_wc_template" id="is_wc_template" ' . $is_wc_template . '>  </input>'; ?>
-                                            <img class="help_tip" width="16" height="16" data-tip='<?php _e( 'Use WooCommerce default style template for abandoned cart reminder emails.', 'woocommerce' ) ?>' src="<?php echo plugins_url(); ?>/woocommerce/assets/images/help.png" /> <a target = '_blank' href= <?php  echo wp_nonce_url( admin_url( '?wcal_preview_woocommerce_mail=true' ), 'woocommerce-abandoned-cart' ) ; ?> > 
-                                            Click here to preview </a>how the email template will look with WooCommerce Template Style enabled. Alternatively, if this is unchecked, the template will appear as <a target = '_blank' href=<?php  echo wp_nonce_url( admin_url( '?wcal_preview_mail=true' ), 'woocommerce-abandoned-cart' ) ; ?>>shown here</a>. <br> <strong>Note: </strong>When this setting is enabled, then "Send From This Name:" & "Send From This Email Address:" will be overwritten with WooCommerce -> Settings -> Email -> Email Sender Options.   
+                                            <img class="help_tip" width="16" height="16" data-tip='<?php _e( 'Use WooCommerce default style template for abandoned cart reminder emails.', 'woocommerce' ) ?>' src="<?php echo plugins_url(); ?>/woocommerce/assets/images/help.png" /> <a target = '_blank' href= <?php  echo wp_nonce_url( admin_url( '?wcal_preview_woocommerce_mail=true' ), 'woocommerce-abandoned-cart' ) ; ?> >
+                                            Click here to preview </a>how the email template will look with WooCommerce Template Style enabled. Alternatively, if this is unchecked, the template will appear as <a target = '_blank' href=<?php  echo wp_nonce_url( admin_url( '?wcal_preview_mail=true' ), 'woocommerce-abandoned-cart' ) ; ?>>shown here</a>. <br> <strong>Note: </strong>When this setting is enabled, then "Send From This Name:" & "Send From This Email Address:" will be overwritten with WooCommerce -> Settings -> Email -> Email Sender Options.
                                         </td>
                                      </tr>
-                                     
+
                                      <tr>
                                         <th>
                                             <label for="wcal_wc_email_header"><b><?php _e( 'Email Template Header Text: ', 'woocommerce-abandoned-cart' ); ?></b></label>
@@ -2852,19 +2852,19 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                         <td>
 
                                         <?php
-                                        
-                                        $wcal_wc_email_header = "";  
+
+                                        $wcal_wc_email_header = "";
                                         if ( 'edittemplate' == $mode && count( $results ) > 0 && isset( $results[0]->wc_email_header ) ) {
                                             $wcal_wc_email_header = $results[0]->wc_email_header;
-                                        }                                           
+                                        }
                                         if ( '' == $wcal_wc_email_header ) {
                                             $wcal_wc_email_header = "Abandoned cart reminder";
                                         }
                                         print'<input type="text" name="wcal_wc_email_header" id="wcal_wc_email_header" class="regular-text" value="' . $wcal_wc_email_header . '">'; ?>
                                         <img class="help_tip" width="16" height="16" data-tip='<?php _e( 'Enter the header which will appear in the abandoned WooCommerce email sent. This is only applicable when only used when "Use WooCommerce Template Style:" is checked.', 'woocommerce-abandoned-cart' ) ?>' src="<?php echo plugins_url(); ?>/woocommerce/assets/images/help.png" />
                                         </td>
-                                    </tr> 
-                                     
+                                    </tr>
+
                                     <tr>
                                         <th>
                                             <label for="woocommerce_ac_email_frequency"><b><?php _e( 'Send this email:', 'woocommerce-abandoned-cart' ); ?></b></label>
@@ -2875,24 +2875,24 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                                 $frequency_edit = "";
                                                 if ( 'edittemplate' == $mode && count( $results ) > 0 && isset( $results[0]->frequency ) ) {
                                                     $frequency_edit = $results[0]->frequency;
-                                                }                                               
+                                                }
                                                 for ( $i = 1; $i < 4; $i++ ) {
                                                     printf( "<option %s value='%s'>%s</option>\n",
                                                         selected( $i, $frequency_edit, false ),
                                                         esc_attr( $i ),
                                                         $i
                                                     );
-                                                }                                           
-                                            ?>  
+                                                }
+                                            ?>
                                             </select>
 
-                                            <select name="day_or_hour" id="day_or_hour">            
+                                            <select name="day_or_hour" id="day_or_hour">
                                                 <?php
                                                 $days_or_hours_edit = "";
                                                 if ( 'edittemplate' == $mode && count( $results ) > 0 && isset( $results[0]->day_or_hour ) )
                                                 {
                                                     $days_or_hours_edit = $results[0]->day_or_hour;
-                                                }                                               
+                                                }
                                                 $days_or_hours = array(
                                                                    'Days'  => 'Day(s)',
                                                                    'Hours' => 'Hour(s)'
@@ -2906,43 +2906,43 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                                     );
                                                 }
                                                 ?>
-                                            </select>           
+                                            </select>
                                             <span class="description">
                                               <?php _e( 'after cart is abandoned.', 'woocommerce-abandoned-cart' ); ?>
                                             </span>
                                         </td>
                                     </tr>
-                                    
+
                                     <tr>
                                         <th>
                                             <label for="woocommerce_ac_email_preview"><b><?php _e( 'Send a test email to:', 'woocommerce-abandoned-cart' ); ?></b></label>
                                         </th>
-                                        <td> 
+                                        <td>
                                             <input type="text" id="send_test_email" name="send_test_email" class="regular-text" >
                                             <input type="button" value="Send a test email" id="preview_email" onclick="javascript:void(0);">
                                             <img class="help_tip" width="16" height="16" data-tip='<?php _e('Enter the email id to which the test email needs to be sent.', 'woocommerce-abandoned-cart') ?>' src="<?php echo plugins_url(); ?>/woocommerce/assets/images/help.png" />
                                             <div id="preview_email_sent_msg" style="display:none;"></div>
                                         </td>
-                                    </tr>                                               
+                                    </tr>
                                 </table>
                             </div>
                         </div>
                     </div>
                       <p class="submit">
                         <?php
-                            $button_value = "Save Changes";
+                            $button_value = __( "Save Changes", 'woocommerce-abandoned-cart' );
                             if ( 'edittemplate' == $mode ) {
-                                $button_value = "Update Changes";
+                                $button_value = __( "Update Changes", 'woocommerce-abandoned-cart' );
                             }
                         ?>
-                        <input type="submit" name="Submit" class="button-primary" value="<?php esc_attr_e( $button_value, 'woocommerce-abandoned-cart' ); ?>"  />
+                        <input type="submit" name="Submit" class="button-primary" value="<?php esc_attr( $button_value ); ?>"  />
                       </p>
                     </form>
               </div>
-             <?php                                                                          
-            }   
+             <?php
+            }
         }
-        
+
         /**
          * It will add the footer text for the plugin.
          * @hook admin_footer_text
@@ -2953,17 +2953,16 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
         function wcal_admin_footer_text( $footer_text ) {
 
             if ( isset( $_GET[ 'page' ] ) && $_GET[ 'page' ] === 'woocommerce_ac_page' ) {
-                $footer_text = sprintf( __( 'If you love <strong>Abandoned Cart Lite for WooCommerce</strong>, then please leave us a <a href="https://wordpress.org/support/plugin/woocommerce-abandoned-cart/reviews/?rate=5#new-post" target="_blank" class="ac-rating-link" data-rated="Thanks :)">★★★★★</a>
-                            rating. Thank you in advance. :)', 'woocommerce-abandoned-cart' ) );
+                $footer_text = __( 'If you love <strong>Abandoned Cart Lite for WooCommerce</strong>, then please leave us a <a href="https://wordpress.org/support/plugin/woocommerce-abandoned-cart/reviews/?rate=5#new-post" target="_blank" class="ac-rating-link" data-rated="Thanks :)">★★★★★</a> rating. Thank you in advance. :)', 'woocommerce-abandoned-cart' );
                 wc_enqueue_js( "
                         jQuery( 'a.ac-rating-link' ).click( function() {
                             jQuery( this ).parent().text( jQuery( this ).data( 'rated' ) );
                         });
-                " );               
-            }            
+                " );
+            }
             return $footer_text;
         }
-        
+
         /**
          * It will sort the record for the product reports tab.
          * @param array $unsort_array Unsorted array
@@ -2971,12 +2970,12 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
          * @return array $array
          * @since 2.6
          */
-        function bubble_sort_function( $unsort_array, $order ) {        
+        function bubble_sort_function( $unsort_array, $order ) {
             $temp = array();
             foreach ( $unsort_array as $key => $value )
-                $temp[ $key ] = $value; //concatenate something unique to make sure two equal weights don't overwrite each other        
+                $temp[ $key ] = $value; //concatenate something unique to make sure two equal weights don't overwrite each other
             asort( $temp, SORT_NUMERIC ); // or ksort( $temp, SORT_NATURAL ); see paragraph above to understand why
-        
+
             if ( 'desc' == $order ) {
                 $array = array_reverse( $temp, true );
             } else if ( $order == 'asc' ) {
@@ -2985,19 +2984,19 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             unset( $temp );
             return $array;
         }
-         
+
         /**
          * It will be called when we send the test email from the email edit page.
          * @hook wp_ajax_wcal_preview_email_sent
          * @since 1.0
-         */        
+         */
         function wcal_action_send_preview() {
             ?>
             <script type="text/javascript" >
                 jQuery( document ).ready( function( $ )
                 {
                     $( "table#addedit_template input#preview_email" ).click( function()
-                    {   
+                    {
                         var email_body = '';
                         if ( jQuery("#wp-woocommerce_ac_email_body-wrap").hasClass( "tmce-active" ) ) {
                             email_body = tinyMCE.get('woocommerce_ac_email_body').getContent();
@@ -3006,10 +3005,10 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                         }
                         var subject_email_preview = $( '#woocommerce_ac_email_subject' ).val();
                         var body_email_preview    = email_body;
-                        var send_email_id         = $( '#send_test_email' ).val();  
-                        var is_wc_template        = document.getElementById( "is_wc_template" ).checked;    
-                        var wc_template_header    = $( '#wcal_wc_email_header' ).val() != '' ? $( '#wcal_wc_email_header' ).val() : 'Abandoned cart reminder';                                                              
-                        var data                  = {                                                       
+                        var send_email_id         = $( '#send_test_email' ).val();
+                        var is_wc_template        = document.getElementById( "is_wc_template" ).checked;
+                        var wc_template_header    = $( '#wcal_wc_email_header' ).val() != '' ? $( '#wcal_wc_email_header' ).val() : 'Abandoned cart reminder';
+                        var data                  = {
                                                         subject_email_preview: subject_email_preview,
                                                         body_email_preview   : body_email_preview,
                                                         send_email_id        : send_email_id,
@@ -3089,20 +3088,20 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
          * It will replace the test email data with the static content.
          * @return string email sent | not sent
          * @since 1.0
-         */      
+         */
         function wcal_preview_email_sent() {
             if ( '' != $_POST['body_email_preview'] ) {
                 $from_email_name       = get_option ( 'wcal_from_name' );
                 $reply_name_preview    = get_option ( 'wcal_from_email' );
                 $from_email_preview    = get_option ( 'wcal_reply_email' );
                 $subject_email_preview = stripslashes ( $_POST['subject_email_preview'] );
-                $subject_email_preview = convert_smilies ( $subject_email_preview ); 
-                $subject_email_preview    = str_replace( '{{customer.firstname}}', 'John', $subject_email_preview );                       
+                $subject_email_preview = convert_smilies ( $subject_email_preview );
+                $subject_email_preview    = str_replace( '{{customer.firstname}}', 'John', $subject_email_preview );
                 $body_email_preview    = convert_smilies ( $_POST['body_email_preview'] );
                 $is_wc_template        = $_POST['is_wc_template'];
                 $wc_template_header    = stripslashes( $_POST['wc_template_header'] );
 
-                $body_email_preview    = str_replace( '{{customer.firstname}}', 'John', $body_email_preview );                                                  
+                $body_email_preview    = str_replace( '{{customer.firstname}}', 'John', $body_email_preview );
                 $body_email_preview    = str_replace( '{{customer.firstname}}', 'John', $body_email_preview );
                 $body_email_preview    = str_replace( '{{customer.lastname}}', 'Doe', $body_email_preview );
                 $body_email_preview    = str_replace( '{{customer.fullname}}', 'John'." ".'Doe', $body_email_preview );
@@ -3110,10 +3109,10 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                 $date_format           = date_i18n( get_option( 'date_format' ), $current_time_stamp );
                 $time_format           = date_i18n( get_option( 'time_format' ), $current_time_stamp );
                 $test_date             = $date_format . ' ' . $time_format;
-                $body_email_preview    = str_replace( '{{cart.abandoned_date}}', $test_date, $body_email_preview );             
+                $body_email_preview    = str_replace( '{{cart.abandoned_date}}', $test_date, $body_email_preview );
                 $cart_url              = wc_get_page_permalink( 'cart' );
                 $body_email_preview    = str_replace( '{{cart.link}}', $cart_url, $body_email_preview );
-                $body_email_preview    = str_replace( '{{cart.unsubscribe}}', '#', $body_email_preview );               
+                $body_email_preview    = str_replace( '{{cart.unsubscribe}}', '#', $body_email_preview );
                 $wcal_price            = wc_price( '100' );
                 $wcal_total_price      = wc_price( '200' );
                 if ( class_exists( 'WP_Better_Emails' ) ) {
@@ -3131,14 +3130,14 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                             </tr>
                                             <tr align="center">
                                                <td><img class="demo_img" width="42" height="42" src="'.plugins_url().'/woocommerce-abandoned-cart/assets/images/shoes.jpg"/></td>
-                                               <td>'.__( "Men\'\s Formal Shoes", 'woocommerce-abandoned-cart' ).'</td>
+                                               <td>'.__( "Men's Formal Shoes", 'woocommerce-abandoned-cart' ).'</td>
                                                <td>1</td>
                                                <td>' . $wcal_price . '</td>
                                                <td>' . $wcal_price . '</td>
                                             </tr>
                                             <tr align="center">
                                                <td><img class="demo_img" width="42" height="42" src="'.plugins_url().'/woocommerce-abandoned-cart/assets/images/handbag.jpg"/></td>
-                                               <td>'.__( "Woman\'\s Hand Bags", 'woocommerce-abandoned-cart' ).'</td>
+                                               <td>'.__( "Woman's Hand Bags", 'woocommerce-abandoned-cart' ).'</td>
                                                <td>1</td>
                                                <td>' . $wcal_price . '</td>
                                                <td>' . $wcal_price . '</td>
@@ -3166,14 +3165,14 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                             </tr>
                                             <tr align="center">
                                                <td><img class="demo_img" width="42" height="42" src="'.plugins_url().'/woocommerce-abandoned-cart/assets/images/shoes.jpg"/></td>
-                                               <td>'.__( "Men\'\s Formal Shoes", 'woocommerce-abandoned-cart' ).'</td>
+                                               <td>'.__( "Men's Formal Shoes", 'woocommerce-abandoned-cart' ).'</td>
                                                <td>1</td>
                                                <td>' . $wcal_price . '</td>
                                                <td>' . $wcal_price . '</td>
                                             </tr>
                                             <tr align="center">
                                                <td><img class="demo_img" width="42" height="42" src="'.plugins_url().'/woocommerce-abandoned-cart/assets/images/handbag.jpg"/></td>
-                                               <td>'.__( "Woman\'\s Hand Bags", 'woocommerce-abandoned-cart' ).'</td>
+                                               <td>'.__( "Woman's Hand Bags", 'woocommerce-abandoned-cart' ).'</td>
                                                <td>1</td>
                                                <td>' . $wcal_price . '</td>
                                                <td>' . $wcal_price . '</td>
@@ -3186,36 +3185,36 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                                                <td>' . $wcal_total_price . '</td>
                                             </tr>
                                          </table>';
-                }                       
-                $body_email_preview     = str_replace( '{{products.cart}}', $var, $body_email_preview );                
+                }
+                $body_email_preview     = str_replace( '{{products.cart}}', $var, $body_email_preview );
                 if ( isset( $_POST['send_email_id'] ) ) {
                       $to_email_preview = $_POST['send_email_id'];
                 } else {
                       $to_email_preview = "";
-                }                
-                $user_email_from          = get_option( 'admin_email' );                
+                }
+                $user_email_from          = get_option( 'admin_email' );
                 $body_email_final_preview = stripslashes( $body_email_preview );
-                
+
                 if ( isset( $is_wc_template ) && 'true' == $is_wc_template ) {
                     ob_start();
                     // Get email heading
                     wc_get_template( 'emails/email-header.php', array( 'email_heading' => $wc_template_header ) );
-                    $email_body_template_header = ob_get_clean();                           
+                    $email_body_template_header = ob_get_clean();
 
-                    ob_start();                         
-                    wc_get_template( 'emails/email-footer.php' );                               
-                    $email_body_template_footer = ob_get_clean();   
-                                            
+                    ob_start();
+                    wc_get_template( 'emails/email-footer.php' );
+                    $email_body_template_footer = ob_get_clean();
+
                     $final_email_body = $email_body_template_header . $body_email_final_preview . $email_body_template_footer;
 
-                    $site_title                 = get_bloginfo( 'name' ); 
-                    $email_body_template_footer = str_replace( '{site_title}', $site_title, $email_body_template_footer ); 
-                    
-                    wc_mail( $to_email_preview, $subject_email_preview, $final_email_body , $headers );    
+                    $site_title                 = get_bloginfo( 'name' );
+                    $email_body_template_footer = str_replace( '{site_title}', $site_title, $email_body_template_footer );
+
+                    wc_mail( $to_email_preview, $subject_email_preview, $final_email_body , $headers );
                 }
                 else {
                     wp_mail( $to_email_preview, $subject_email_preview, stripslashes( $body_email_preview ), $headers );
-                }                   
+                }
                 echo "email sent";
                 die();
             } else {
@@ -3223,7 +3222,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                 die();
             }
         }
-    }   
-}       
+    }
+}
 $woocommerce_abandon_cart = new woocommerce_abandon_cart_lite();
 ?>


### PR DESCRIPTION
Hello,

This PR covers several issues with the available strings for translations I found while translating the plugin.

Overview of changes;
- Don't apply translation function to single variables.
- Removed variables form strings and either appended or used sprintf to include them (when using sprintf I made sure to supply translator comments)
- Apply translation functions to strings that weren't previously translated

Please review and test and I'm happy to discuss.

Cheers

P.S. Some notes in the internationalization documents that cover why variables shouldn't be in translation functions;
https://codex.wordpress.org/I18n_for_WordPress_Developers
https://developer.wordpress.org/themes/functionality/internationalization/