### PR TITLE
Change the default loaded tab when WC->Abandoned Orders menu is accessed

### DIFF
--- a/woocommerce-abandoned-cart/woocommerce-ac.php
+++ b/woocommerce-abandoned-cart/woocommerce-ac.php
@@ -1637,7 +1637,12 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
             $active_stats          = '';
             $active_dash           = '';
 
-            $action = isset( $_GET[ 'action' ] ) ? $_GET[ 'action' ] : '';
+            if( isset( $_GET[ 'action' ] ) ) {
+                $action = $_GET[ 'action' ];
+            } else {
+                $action = '';
+                $action = apply_filters( 'wcal_default_tab', $action );
+            }
             
             switch( $action ) {
                 case '':
@@ -1893,6 +1898,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
                     $action = $_GET['action'];
                 } else {
                     $action = "";
+                    $action = apply_filters( 'wcal_default_tab', $action );
                 }
                 if ( isset( $_GET['mode'] ) ) {
                     $mode = $_GET['mode'];


### PR DESCRIPTION
In the last update, a new tab Dashboard was added for the plugin which
is now loaded when WC->Abandoned Orders menu is accessed.

More than 1 client wants the Abandoned Orders tab to be loaded by
default.

So we've now added a hook using which the site admin can choose which
tab should be loaded.

Custom code which needs to be added to the functions.php file:

add_filter( 'wcal_default_tab', 'change_default_tab', 10, 1 );

function change_default_tab( $action ) {
return 'listcart';
}

In a scenario where the site admin wishes to load some other tab. the
tab name can be found by accessing the tab and checking the 'action'
value in the url.