### PR TITLE
New hook for product name change in reminder email

### DIFF
--- a/woocommerce-abandoned-cart/cron/wcal_send_email.php
+++ b/woocommerce-abandoned-cart/cron/wcal_send_email.php
@@ -358,6 +358,7 @@ if ( !class_exists( 'woocommerce_abandon_cart_cron' ) ) {
                                                                 }
                                                                 $product_name = $product_name_with_variable;
                                                             }
+                                                            $product_name = apply_filters( 'wcal_after_product_name', $product_name, $v );
                                                             $var .='<tr align="center">
                                                                     <td> <a href="'.$cart_link_track.'"> <img src="' . $image_url . '" alt="" height="42" width="42" /> </a></td>
                                                                     <td> <a href="'.$cart_link_track.'">'.$product_name.'</a></td>


### PR DESCRIPTION
Added a new hook which will allow the user to update/customize the
product name shown in reminder emails.

https://wordpress.org/support/topic/why-the-name-of-the-product-shown-in-email-includes-sku/