### PR TITLE
Plugin strings are not available for translation

### DIFF
--- a/woocommerce-abandoned-cart/woocommerce-ac.php
+++ b/woocommerce-abandoned-cart/woocommerce-ac.php
@@ -35,6 +35,8 @@ require_once( 'includes/admin/wcap_pro_settings.php' );
 require_once( 'includes/admin/wcap_pro_settings_callbacks.php' );
 require_once( 'includes/admin/wcap_add_cart_popup_modal.php' );
 
+load_plugin_textdomain( 'woocommerce-abandoned-cart', false, basename( dirname( __FILE__ ) ) . '/i18n/languages' );
+
 /**
  * Schedule an action to delete old carts once a day
  *


### PR DESCRIPTION
In a scenario where the site language is other than English(e.g. Lithuanian) and the .po file for the language is present in the plugin the admin end and reminder emails are still sent in English.

Note: No translation plugin is used.