### PR TITLE
Fix 1040

### DIFF
--- a/cron/class-wcal-cron.php
+++ b/cron/class-wcal-cron.php
@@ -491,6 +491,7 @@ if ( ! class_exists( 'Wcal_Cron' ) ) {
 														wc_mail( $user_email, $email_subject, $final_email_body, $headers );
 
 													} else {
+														$email_subject = wp_specialchars_decode( $email_subject );
 														wp_mail( $user_email, $email_subject, $email_body_final, $headers );
 													}
 												}


### PR DESCRIPTION
When sending abandoned cart reminder emails using `wp_mail()`, the email subject contains HTML-encoded characters (e.g., `A&amp;A` Vesa) instead of the intended special characters (`A&A Vesa`). This happens because `wp_mail()` does not decode HTML entities, unlike `wc_mail()` which processes the subject before sending.

Fix #1040 