### PR TITLE
Exclude bot-generated carts when tracking starts from Cart page

### DIFF
--- a/woocommerce-ac.php
+++ b/woocommerce-ac.php
@@ -1794,6 +1794,14 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
 				'baiduspider',
 				'sogou',
 				'ia_archiver',
+				'crawler',
+				'spider',
+				'ahrefs',
+				'semrush',
+				'mj12bot',
+				'dotbot',
+				'bingpreview',
+				'facebookexternalhit',
 			);
 
 			foreach ( $bot_agents as $url ) {


### PR DESCRIPTION
Improves abandoned cart tracking when “Start tracking from Cart page” is enabled by preventing bot-generated carts from being logged. Enhances existing crawler detection and adds basic validation to ensure only genuine user carts are recorded, reducing noise caused by bot traffic.

Fix #1053