### PR TITLE
Updated the recently added features on the WordPress.org page

### DIFF
--- a/includes/class-wcal-common.php
+++ b/includes/class-wcal-common.php
@@ -998,6 +998,8 @@ class wcal_common { // phpcs:ignore
 			$user_id   = isset( $cart_data[0]->user_id ) ? $cart_data[0]->user_id : 0;
 			$user_type = isset( $cart_data[0]->user_type ) ? $cart_data[0]->user_type : '';
 
+			// Allow modifying user_id and user_type via filter.
+			$user_id = apply_filters( 'ac_lite_abandoned_cart_user_id', $user_id );
 			if ( $user_id > 0 && '' != $user_type && '0' == $cart_data[0]->cart_ignored && $cart_data[0]->recovered_cart <= 0 ) { // phpcs:ignore
 				$cut_off = is_numeric( get_option( 'ac_lite_cart_abandoned_time', 10 ) ) ? get_option( 'ac_lite_cart_abandoned_time', 10 ) * 60 : 10 * 60;
 

--- a/readme.txt
+++ b/readme.txt
@@ -31,6 +31,8 @@ The FREE Abandoned Cart Lite for WooCommerce is bundled with all the essential f
 * Check if the cart is abandoned by the guest client or logged in user
 * Tracking percentage of recovery done
 * Send a reminder email within a few minutes after the cart gets abandoned
+* Send an email notification to the store admin when a cart is abandoned, so the admin is informed whenever cart abandonment happens
+* Exclude abandoned carts from being tracked based on IP address, email, domain, or country, allowing admins to control which carts are captured
 * Abandoned cart templates for quick setup
 * Copy HTML from anywhere & create templates using the powerful Rich Text Editor
 * A handy report showing the number of times a product was abandoned and recovered


### PR DESCRIPTION
Updated the recently added features on the WordPress.org page & Introduced a new filter `ac_lite_abandoned_cart_user_id` to trigger the webhook only for visitor carts with empty user data.

Please add the following filter to your active theme's `functions.php` file (or via a Code Snippets plugin):

```
add_filter( 'ac_lite_abandoned_cart_user_id', function( $user_id ) {
    if ( empty( $user_id ) ) {
        $user_id = 63000000;
    }
    return $user_id;
}, 10 );
```

Fix #1067 