### PR TITLE
Replace deprecated wc_enqueue_js() with wp_add_inline_script()

### DIFF
--- a/woocommerce-ac.php
+++ b/woocommerce-ac.php
@@ -4123,7 +4123,8 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
 
 			if ( isset( $_GET['page'] ) && 'woocommerce_ac_page' === $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification
 				$footer_text = __( 'If you love <strong>Abandoned Cart Lite for WooCommerce</strong>, then please leave us a <a href="https://wordpress.org/support/plugin/woocommerce-abandoned-cart/reviews/?rate=5#new-post" target="_blank" class="ac-rating-link" data-rated="Thanks :)">★★★★★</a> rating. Thank you in advance. :)', 'woocommerce-abandoned-cart' );
-				wc_enqueue_js(
+				wp_add_inline_script(
+					'jquery',
 					"
 						jQuery( 'a.ac-rating-link' ).click( function() {
 							jQuery( this ).parent().text( jQuery( this ).data( 'rated' ) );


### PR DESCRIPTION
Replaced usage of deprecated `wc_enqueue_js()` with `wp_add_inline_script()` in admin footer. Ensured `jquery` is properly enqueued and used as the script handle for attaching inline JS. This prevents deprecation warnings in WooCommerce 10.4+ and aligns with current WordPress standards.

https://wordpress.org/support/topic/wc_enqueue_js/

Fix #1070 