### PR TITLE
Fix undefined variable in wcal_send_email_notification()

### DIFF
--- a/cron/class-wcal-cron.php
+++ b/cron/class-wcal-cron.php
@@ -317,12 +317,13 @@ if ( ! class_exists( 'Wcal_Cron' ) ) {
                                                                 <th>' . apply_filters( 'wcal_reminder_email_line_subtotal_header', $line_subtotal_header ) . '</th>
                                                                 </tr>';
 														}
-														$cart_details       = $cart_info_db_field->cart;
-														$cart_total         = 0;
-														$item_subtotal      = 0;
-														$item_total         = 0;
-														$sub_line_prod_name = '';
-														$line_subtotal_tax  = 0;
+														$cart_details              = $cart_info_db_field->cart;
+														$cart_total                = 0;
+														$item_subtotal             = 0;
+														$item_total                = 0;
+														$sub_line_prod_name        = '';
+                                                        $line_subtotal_tax         = 0;
+                                                        $line_subtotal_tax_display = 0;
 														foreach ( $cart_details as $k => $v ) {
 															$quantity_total = $v->quantity;
 															$product_id     = $v->product_id;


### PR DESCRIPTION
This PR fixes an undefined variable warning in the emails reminders cron:

```
PHP Warning:  Undefined variable $line_subtotal_tax_display in /var/www/[...]/plugins/woocommerce-abandoned-cart/cron/class-wcal-cron.php on line 352
```