### PR TITLE
Fix : Stored XSS Vulnerability in Email Template Preview Due to Unsanitized Template Body

### DIFF
--- a/woocommerce-ac.php
+++ b/woocommerce-ac.php
@@ -511,7 +511,8 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
 					}
 					$message = $email_body_template_header . $message . $email_body_template_footer;
 				}
-				echo $message; // phpcs:ignore
+				header( 'Content-Security-Policy: sandbox' );
+				echo wp_unslash( $message ); // phpcs:ignore
 				exit;
 			}
 
@@ -539,7 +540,8 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
 					$message = ob_get_clean();
 				}
 				// print the preview email.
-				echo $message; // phpcs:ignore
+				header( 'Content-Security-Policy: sandbox' );
+				echo wp_unslash( $message ); // phpcs:ignore
 				exit;
 			}
 		}


### PR DESCRIPTION
Added `wp_unslash()` and isolate the standalone preview response using `Content-Security-Policy: sandbox` to prevent execution of active content while preserving full email template compatibility.

Fix #1074