### PR TITLE
Add nonce protection for email template database update action

### DIFF
--- a/includes/class-wcal-admin-notice.php
+++ b/includes/class-wcal-admin-notice.php
@@ -61,6 +61,11 @@ class Wcal_Admin_Notice {
 			'SHOW FULL COLUMNS FROM `' . $wpdb->prefix . 'ac_email_templates_lite` WHERE Field = "subject" OR Field = "body"'
 		);
 
+		$update_url = wp_nonce_url(
+			admin_url( 'admin.php?page=woocommerce_ac_page&action=listcart&ac_update=email_templates' ),
+			'wcal_update_email_templates'
+		);
+
 		foreach ( $results as $key => $value ) {
 			if ( 'utf8mb4_unicode_ci' !== $value->Collation ) { // phpcs:ignore
 				?>
@@ -69,7 +74,7 @@ class Wcal_Admin_Notice {
 						<?php echo esc_html__( 'We need to update your email template database for some improvements. Please take a backup of your databases for your piece of mind.', 'woocommerce-abandoned-cart' ); ?>
 					</span>
 					<span class="submit">
-						<a href="<?php echo esc_url( 'admin.php?page=woocommerce_ac_page&action=listcart&ac_update=email_templates' ); ?>" class="button-primary" style="float:right;"><?php echo esc_html__( 'Update', 'woocommerce-abandoned-cart' ); ?></a>
+						<a href="<?php echo esc_url( $update_url ); ?>" class="button-primary" style="float:right;"><?php echo esc_html__( 'Update', 'woocommerce-abandoned-cart' ); ?></a>
 					</span>
 				</div>
 				<?php

--- a/woocommerce-ac.php
+++ b/woocommerce-ac.php
@@ -2907,6 +2907,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
 				'bulk-abandoned_order_ids',  // Bulk dropdown on abandoned orders list (auto by WP_List_Table).
 				'bulk-template_ids',         // Bulk dropdown on email templates list (auto by WP_List_Table).
 				'wcal_email_template_form',  // Create / update email template form.
+				'wcal_update_email_templates',
 			);
 
 			if ( '' !== $nonce ) {


### PR DESCRIPTION
This PR secures the email template database update process by adding a dedicated nonce to the Update button URL and validating it before executing the update. This prevents unauthorized requests and resolves the "The link you followed has expired" error introduced by the nonce verification patch.

Fix #1078