### PR TITLE
Fix: Add index on session_id to prevent full table scans in cart tracking

### DIFF
--- a/class-wcal-update.php
+++ b/class-wcal-update.php
@@ -126,6 +126,7 @@ if ( ! class_exists( 'Wcal_Update' ) ) {
 			}
 
 			self::wcal_alter_tables( $db_prefix, $blog_id );
+			self::wcal_add_session_id_index( $db_prefix, $blog_id );
 			self::wcal_individual_settings( $blog_id );
 			self::wcal_cleanup( $db_prefix, $blog_id );
 
@@ -293,6 +294,42 @@ if ( ! class_exists( 'Wcal_Update' ) ) {
 			if ( ! $wpdb->get_var( 'SHOW COLUMNS FROM ' . $db_prefix . "ac_email_templates_lite LIKE 'email_type'" ) ) { //phpcs:ignore
 				$wpdb->query( 'ALTER TABLE ' . $db_prefix . 'ac_email_templates_lite ADD COLUMN `email_type` ENUM("0","1") CHARSET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL AFTER `id`' ); //phpcs:ignore
 			}
+		}
+		/**
+		 * Add an index on session_id to the abandoned cart history table.
+		 *
+		 * The hot-path lookup in wcal_store_cart_timestamp() previously full-scanned
+		 * this table because no index existed on session_id. On large stores this
+		 * caused significant DB load.
+		 *
+		 * @param string $db_prefix - DB Prefix.
+		 * @param int    $blog_id   - Blog ID (needed for multisites).
+		 *
+		 * @since 6.8.2
+		 */
+		public static function wcal_add_session_id_index( $db_prefix, $blog_id ) {
+
+			global $wpdb;
+
+			if ( 0 === $blog_id ) {
+				$index_added = get_option( 'wcal_session_id_index_added' );
+			} else {
+				$index_added = get_blog_option( $blog_id, 'wcal_session_id_index_added' );
+			}
+
+			if ( 'yes' === $index_added ) {
+				return;
+			}
+
+			$table = $db_prefix . 'ac_abandoned_cart_history_lite';
+
+			if ( $wpdb->get_var( "SHOW TABLES LIKE '{$table}'" ) ) { // phpcs:ignore
+				$exists = $wpdb->get_var( "SHOW INDEX FROM `{$table}` WHERE Key_name = 'session_id'" ); // phpcs:ignore
+				if ( ! $exists ) {
+					$wpdb->query( "ALTER TABLE `{$table}` ADD INDEX `session_id` (`session_id`)" ); // phpcs:ignore
+				}
+			}
+			self::wcal_update_option( $blog_id, 'wcal_session_id_index_added', 'yes' );
 		}
 		/**
 		 * Add a new column email_reminder_status in the cart history lite table.

--- a/woocommerce-ac.php
+++ b/woocommerce-ac.php
@@ -692,7 +692,8 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
 				`session_id` varchar(50) COLLATE utf8_unicode_ci NOT NULL,
 				`email_reminder_status` varchar(50) COLLATE utf8_unicode_ci NOT NULL,
 				`checkout_link` varchar(500) COLLATE utf8_unicode_ci NOT NULL,
-				PRIMARY KEY (`id`)
+				PRIMARY KEY (`id`),
+				KEY `session_id` (`session_id`)
 				) $wcap_collate" // phpcs:ignore
 			);
 
@@ -1851,7 +1852,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
 						if ( 'on' === $track_guest_user_cart_from_cart && isset( $get_cookie ) && '' !== $get_cookie ) {
 							$results = $wpdb->get_results( //phpcs:ignore
 								$wpdb->prepare(
-									'SELECT * FROM `' . $wpdb->prefix . 'ac_abandoned_cart_history_lite` WHERE session_id LIKE %s AND cart_ignored = %s AND recovered_cart = %s',
+									'SELECT * FROM `' . $wpdb->prefix . 'ac_abandoned_cart_history_lite` WHERE session_id = %s AND cart_ignored = %s AND recovered_cart = %s',
 									$get_cookie,
 									0,
 									0


### PR DESCRIPTION
**Cause:**

The `ac_abandoned_cart_history_lite` table has no index on `session_id`. `wcal_store_cart_timestamp()` runs a `SELECT ... WHERE session_id LIKE %s` query (`woocommerce-ac.php` L1854) on every WooCommerce cart action it hooks — `woocommerce_add_to_cart`, `woocommerce_calculate_totals`, and three others (L210–214). On stores with large history tables, this forces a full table scan on every cart/checkout pageview, driving high MySQL CPU load under concurrent traffic.

**EXPLAIN on a 1.4M-row table:**

| | type | key | rows | filtered | time |
|---|---|---|---|---|---|
| Before | `ALL` | `NULL` | 1,456,866 | 2.50 | ~3s |
| After | `ref` | `session_id` | 1 | 100.00 | 0.00s |

**Fix:**

1. **`woocommerce-ac.php` L1854** — swap `LIKE` for `=`. Only `$results[0]` is consumed downstream. `LIKE %s` was also treating underscores in session tokens as wildcards, since `$wpdb->prepare()` does not escape `LIKE` metacharacters.
4. **`woocommerce-ac.php` L695** — add `KEY` session_id` (`session_id`)` to the `CREATE TABLE` for new installs.
6. **`class-wcal-update.php`** — new `wcal_add_session_id_index()` method called from `wcal_process_db_update()`, gated by the `wcal_session_id_index_added` option flag, using `SHOW INDEX` existence check before `ALTER TABLE`. Runs once per site on version bump via the existing `wcal_update_db` action; multisite-aware via the existing `$blog_id` loop.

https://wordpress.org/support/topic/slow-mysql-query-on-ac_abandoned_cart_history_lite-table/