### PR TITLE
[Security] Fix unauthenticated account takeover via forged cart-recovery link

### DIFF
--- a/cron/class-wcal-cron.php
+++ b/cron/class-wcal-cron.php
@@ -267,7 +267,7 @@ if ( ! class_exists( 'Wcal_Cron' ) ) {
 													}
 													$cart_page_link  = apply_filters( 'wcal_cart_link_email_before_encoding', $cart_page_link, $value->id );
 													$encoding_cart   = $email_sent_id . '&url=' . $cart_page_link . $utm;
-													$validate_cart   = wcal_common::wcal_encrypt_validate( $encoding_cart, $crypt_key );
+													$validate_cart   = wcal_common::wcal_encrypt_validate_hmac( $encoding_cart, $crypt_key ); // v6.8.2: HMAC-tagged token for recovery link
 													$cart_link_track = get_option( 'siteurl' ) . '/?wcal_action=track_links&user_email=' . $value->user_email . '&validate=' . $validate_cart;
 
 													list( $email_body , $coupon_code_to_apply ) = wcal_common::wcal_check_and_replace_email_tag( $email_body, $wc_email_template );

--- a/includes/class-wcal-common.php
+++ b/includes/class-wcal-common.php
@@ -1042,7 +1042,7 @@ class wcal_common { // phpcs:ignore
 		if ( '' !== $user_email ) {
 			$crypt_key         = wcal_get_crypt_key( $user_email, true, $cart_id );
 			$encoding_checkout = $cart_id . '&url=' . $checkout_page_link;
-			$validate_checkout = wcal_common::wcal_encrypt_validate( $encoding_checkout, $crypt_key );
+			$validate_checkout = wcal_common::wcal_encrypt_validate_hmac( $encoding_checkout, $crypt_key ); // v6.8.2: HMAC-tagged token for checkout link
 
 			$checkout_link = get_option( 'siteurl' ) . '/?wcal_action=checkout_link&user_email=' . $user_email . '&validate=' . $validate_checkout;
 			$wpdb->update( // phpcs:ignore
@@ -1071,6 +1071,32 @@ class wcal_common { // phpcs:ignore
 		if ( '' !== $crypt_key ) {
 			$validate_encoded = Wcal_Aes_Ctr::encrypt( $validate, $crypt_key, 256 );
 			return( $validate_encoded );
+		}
+		return false;
+	}
+
+	/**
+	 * Encrypt a value and append an HMAC-SHA256 integrity tag.
+	 *
+	 * Use this instead of wcal_encrypt_validate() only for tokens verified by
+	 * wcal_verify_and_strip_hmac() on receipt (recovery & checkout cart links).
+	 * Do NOT use for coupon or unsubscribe tokens — those handlers call
+	 * Wcal_Aes_Ctr::decrypt() directly and would receive corrupt plaintext.
+	 *
+	 * Output format: <base64-ciphertext>.<hex-hmac>
+	 *
+	 * Security fix for unauthenticated account takeover (Shivamani Vastrala / v6.8.2).
+	 *
+	 * @param string $validate  Plaintext to encrypt.
+	 * @param string $crypt_key Per-email encryption key.
+	 * @return string|false     HMAC-tagged token, or false if key is empty.
+	 * @since 6.8.2
+	 */
+	public static function wcal_encrypt_validate_hmac( $validate, $crypt_key ) {
+		if ( '' !== $crypt_key ) {
+			$ciphertext = Wcal_Aes_Ctr::encrypt( $validate, $crypt_key, 256 );
+			$hmac       = hash_hmac( 'sha256', $ciphertext, $crypt_key );
+			return $ciphertext . '.' . $hmac;
 		}
 		return false;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -169,8 +169,8 @@ This plugin communicates with our tracking server to send usage data **only** if
 == Changelog ==
 
 = 6.8.1 (13.06.2026) =
-* Fix - Resolved a stored XSS vulnerability in the email template preview by sanitizing the template body on save and escaping its output during preview rendering.
-* Fix - Resolved a CSRF vulnerability in the Abandoned Cart admin handler by enforcing nonce verification in `wcal_menu_page()` across abandoned cart deletion actions and email template create, update, activate, deactivate, and delete actions.
+* Fix - Resolved a stored Cross-Site Scripting vulnerability in the email template preview by sanitizing the template body on save and escaping its output during preview rendering.
+* Fix - Resolved a Cross-Site Request Forgery vulnerability in the Abandoned Cart admin handler by enforcing nonce verification in `wcal_menu_page()` across abandoned cart deletion actions and email template create, update, activate, deactivate, and delete all actions.
 
 = 6.8.0 (15.05.2026) =
 * Tweak - Added ac_lite_abandoned_cart_user_id filter to enable webhook for guest carts without user ID.

--- a/readme.txt
+++ b/readme.txt
@@ -169,8 +169,8 @@ This plugin communicates with our tracking server to send usage data **only** if
 == Changelog ==
 
 = 6.8.1 (13.06.2026) =
-* Fix - Resolved a stored Cross-Site Scripting vulnerability in the email template preview by sanitizing the template body on save and escaping its output during preview rendering.
-* Fix - Resolved a Cross-Site Request Forgery vulnerability in the Abandoned Cart admin handler by enforcing nonce verification in `wcal_menu_page()` across abandoned cart deletion actions and email template create, update, activate, deactivate, and delete all actions.
+* Fix - Resolved a stored XSS vulnerability in the email template preview by sanitizing the template body on save and escaping its output during preview rendering.
+* Fix - Resolved a CSRF vulnerability in the Abandoned Cart admin handler by enforcing nonce verification in `wcal_menu_page()` across abandoned cart deletion actions and email template create, update, activate, deactivate, and delete actions.
 
 = 6.8.0 (15.05.2026) =
 * Tweak - Added ac_lite_abandoned_cart_user_id filter to enable webhook for guest carts without user ID.

--- a/woocommerce-ac.php
+++ b/woocommerce-ac.php
@@ -2105,7 +2105,24 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
 					}
 				}
 				if ( ! empty( $crypt_key ) && null !== $crypt_key && '' !== $crypt_key ) {
-					$link_decode       = Wcal_Aes_Ctr::decrypt( $validate_encoded_string, $crypt_key, 256 );
+
+					// ── SECURITY FIX #1081.1 (Shivamani Vastrala / v6.8.2) ───
+					$hmac_result = self::wcal_verify_and_strip_hmac( $validate_encoded_string, $crypt_key );
+					if ( 'tampered' === $hmac_result['status'] ) {
+						// Tag present but invalid — hard reject, do not decrypt.
+						if ( version_compare( $woocommerce->version, '3.0.0', '>=' ) ) {
+							wp_safe_redirect( get_permalink( wc_get_page_id( 'shop' ) ) );
+						} else {
+							wp_safe_redirect( get_permalink( woocommerce_get_page_id( 'shop' ) ) );
+						}
+						exit;
+					}
+					// 'valid'  → HMAC verified, use stripped ciphertext.
+					// 'legacy' → no tag (pre-6.8.2 email), token used as-is.
+					$verified_ciphertext = $hmac_result['ciphertext'];
+					// ── END FIX #1081.1 ──
+
+					$link_decode       = Wcal_Aes_Ctr::decrypt( $verified_ciphertext, $crypt_key, 256 );
 					$sent_email_id_pos = strpos( $link_decode, '&' );
 					$email_sent_id     = substr( $link_decode, 0, $sent_email_id_pos );
 
@@ -2138,9 +2155,32 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
 					} elseif ( 'checkout_link' === $track_link ) {
 						$abandoned_id     = 0;
 						$abandoned_id_pos = strpos( $link_decode, '&' );
-						$abandoned_id     = substr( $link_decode, 0, $abandoned_id_pos );
+						$abandoned_id     = (int) substr( $link_decode, 0, $abandoned_id_pos );
 						wcal_common::wcal_set_cart_session( 'wcal_recovered_cart', true );
 					}
+
+					// ── SECURITY FIX #1081.2 (Shivamani Vastrala / v6.8.2).
+					// Verify the decrypted abandoned_id belongs to the supplied user_email before proceeding. This prevents malicious users from manipulating the URL to access other users' carts.
+					if ( $abandoned_id > 0 ) {
+						$binding_check = $wpdb->get_var( // phpcs:ignore
+							$wpdb->prepare(
+								'SELECT COUNT(*) FROM `' . $wpdb->prefix . 'ac_sent_history_lite`
+								 WHERE abandoned_order_id = %d
+								   AND sent_email_id      = %s',
+								$abandoned_id,
+								$sent_email
+							)
+						);
+						if ( ! $binding_check || intval( $binding_check ) < 1 ) {
+							if ( version_compare( $woocommerce->version, '3.0.0', '>=' ) ) {
+								wp_safe_redirect( get_permalink( wc_get_page_id( 'shop' ) ) );
+							} else {
+								wp_safe_redirect( get_permalink( woocommerce_get_page_id( 'shop' ) ) );
+							}
+							exit;
+						}
+					}
+					// ── END FIX #1081.2 ──
 
 					$url_pos = strpos( $link_decode, '=' );
 					++$url_pos;
@@ -2231,6 +2271,58 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
 				return $template;
 			}
 		}
+		/**
+		 * Append an HMAC-SHA256 tag to an AES-CTR ciphertext token.
+		 *
+		 * The HMAC key is derived from the per-email encrypt_key already stored in
+		 * ac_sent_history_lite, so no new secret needs to be introduced.
+		 * Output format: <base64-ciphertext>.<hex-hmac>
+		 *
+		 * Security fix for CVE / coordinated disclosure by Shivamani Vastrala.
+		 *
+		 * @param string $ciphertext  Base64-encoded AES-CTR output.
+		 * @param string $crypt_key   Per-email encryption key.
+		 * @return string             Integrity-protected token.
+		 * @since 6.8.2
+		 */
+		private static function wcal_append_hmac( $ciphertext, $crypt_key ) {
+			$hmac = hash_hmac( 'sha256', $ciphertext, $crypt_key );
+			return $ciphertext . '.' . $hmac;
+		}
+
+		/**
+		 * Verify the HMAC tag on a recovery token and return the bare ciphertext.
+		 *
+		 * Uses hash_equals() for constant-time comparison to prevent timing oracles.
+		 * Returns false for tokens with no tag (legacy tokens are rejected to avoid
+		 * downgrade attacks) and for tokens whose tag does not match.
+		 *
+		 * Security fix for CVE / coordinated disclosure by Shivamani Vastrala.
+		 *
+		 * @param string $token      Full token (<ciphertext>.<hmac>).
+		 * @param string $crypt_key  Per-email encryption key.
+		 * @return string|false      Bare ciphertext on success; false on failure.
+		 * @since 6.8.2
+		 */
+		private static function wcal_verify_and_strip_hmac( $token, $crypt_key ) {
+			$dot = strrpos( $token, '.' );
+			if ( false === $dot ) {
+				// No dot separator — pre-6.8.2 legacy token with no HMAC tag.
+				// Return the token as-is so the caller can decrypt it via the
+				// legacy path and keep old recovery emails working.
+				return array( 'status' => 'legacy', 'ciphertext' => $token );
+			}
+			$ciphertext    = substr( $token, 0, $dot );
+			$provided_hmac = substr( $token, $dot + 1 );
+			$expected_hmac = hash_hmac( 'sha256', $ciphertext, $crypt_key );
+			// Constant-time comparison prevents timing-based HMAC oracle attacks.
+			if ( ! hash_equals( $expected_hmac, $provided_hmac ) ) {
+				// Tag present but wrong — genuine tampering attempt; reject hard.
+				return array( 'status' => 'tampered', 'ciphertext' => false );
+			}
+			return array( 'status' => 'valid', 'ciphertext' => $ciphertext );
+		}
+
 		/**
 		 * Populate WC Session with values on user login.
 		 *


### PR DESCRIPTION
Fixes a critical unauthenticated account takeover vulnerability in the cart-recovery link handler, reported by security researcher Shivamani Vastrala via coordinated disclosure.

The `wcal_email_track_links` handler had two issues. First, AES-CTR encryption was used with no integrity check, allowing an attacker to bit-flip a valid token and substitute a victim's cart ID. Second, even without that, the decrypted cart record was never verified to belong to the supplied email before issuing a session — meaning a cross-user token swap went undetected. With "Auto login users" enabled, this results in full account takeover. On the default config, guest cart PII is disclosed.

## Testing Instructions

### Setup
- Abandon some carts as both logged-in users and guests using the 6.8.1 plugin.
- Update the patched plugin copy on your site.
- Abandon some more carts as logged-in users and guests, using a different email address for each cart.
- Enable **Auto login users** under WooCommerce → Abandoned Cart → Settings.

---

### Test 1 — New recovery email works
1. Abandon a cart as a logged-in user.
2. Wait for, or manually trigger, the abandoned cart recovery email.
3. Click the recovery link in the email.
4. **Expected:** Cart is restored, user is logged in, and redirected correctly. No errors.

---

### Test 2 — Old recovery email still works
1. Using the 6.8.1 plugin, send a recovery email to any customer and copy the recovery URL before upgrading.
2. Upload latest master copy.
3. Click the copied 6.8.1 recovery URL.
4. **Expected:** Cart is restored and the flow completes normally. User is not redirected to the shop. The legacy (no-HMAC) token is accepted.

---

### Test 3 — Tampered token is rejected
1. Obtain a valid recovery URL from a sent email.
2. Manually alter one character in the `validate` query parameter (after the `.` separator).
3. Visit the modified URL while unauthenticated.
4. **Expected:** Redirected to the shop page. No session created. No cart loaded.

---

### Test 4 — Cross-user token is rejected
1. Send a recovery email and copy the full recovery URL.
2. Manually change the `user_email` parameter in the URL to `victim@example.com`.
3. Visit the modified URL while unauthenticated.
4. **Expected:** Redirected to the shop page. No session created. Not logged in as the victim.

---

### Test 5 — Unsubscribe link still works
1. Send a recovery email to any customer.
2. Click the unsubscribe link in the email.
3. **Expected:** "Unsubscribed Successfully" message appears and the customer is unsubscribed. No errors.

---

### Test 6 — Coupon code in recovery email still applies
1. Create a WooCommerce coupon code.
2. Add the coupon tag to a recovery email template.
3. Trigger a recovery email to a test customer.
4. Click the recovery link.
5. **Expected:** Cart is restored and the coupon is applied automatically. No errors.

---

### Test 7 — Auto login OFF still loads cart correctly
1. Disable **Auto login users** under Settings.
2. Trigger a recovery email and click the link while logged out.
3. **Expected:** User is redirected to the My Account page (not logged in) and cart data is preserved in session. No errors.

Fixes #1081