### PR TITLE
Improve email preview security by enforcing a restrictive Content Security Policy

### DIFF
--- a/woocommerce-ac.php
+++ b/woocommerce-ac.php
@@ -511,7 +511,13 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
 					}
 					$message = $email_body_template_header . $message . $email_body_template_footer;
 				}
-				header( 'Content-Security-Policy: sandbox' );
+				header(
+					"Content-Security-Policy: sandbox; " .
+					"default-src 'self'; " .
+					"style-src 'self' 'unsafe-inline' https:; " .
+					"font-src 'self' https:; " .
+					"img-src 'self' data: https:;"
+				);
 				echo wp_unslash( $message ); // phpcs:ignore
 				exit;
 			}
@@ -540,7 +546,13 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
 					$message = ob_get_clean();
 				}
 				// print the preview email.
-				header( 'Content-Security-Policy: sandbox' );
+				header(
+					"Content-Security-Policy: sandbox; " .
+					"default-src 'self'; " .
+					"style-src 'self' 'unsafe-inline' https:; " .
+					"font-src 'self' https:; " .
+					"img-src 'self' data: https:;"
+				);
 				echo wp_unslash( $message ); // phpcs:ignore
 				exit;
 			}


### PR DESCRIPTION
Updated the email preview Content Security Policy from a basic `sandbox` directive to a more restrictive policy that explicitly limits allowed resource sources. This ensures that email template content is safely rendered in the preview, preventing JavaScript or other malicious HTML from executing. Potentially unsafe content is blocked and rendered safely instead of being executed.

Fix #1087

**Testing Instructions:**
1. Open the any email template.
2. Add a <script> tag to the email template body & save the template.
3. Preview the email template.
4. Verify that the script does not execute and that no JavaScript alert or malicious behavior occurs.
5. Confirm that the preview renders safely, with unsupported content either removed or displayed as plain text, while valid HTML formatting continues to render correctly.